### PR TITLE
remove links to prints

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,7 @@ Here's a general overview of the Lob services available, click through to read m
 - [Postcards API](https://lob.com/services/postcards)
 - [Letters API](https://lob.com/services/letters)
 - [Checks API](https://lob.com/services/checks)
-- [Prints API](https://lob.com/services/sps)
-- [Area Mail API](https://lob.com/services/sam)
+- [Area Mail API](https://lob.com/services/area)
 - [Address Verification API](https://lob.com/verification/address)
 
 ### Registration
@@ -98,20 +97,6 @@ We've provided various examples for you to try out [here](https://github.com/lob
     - [Delete a Bank Account](https://lob.com/docs/php#bankaccounts_delete)
     - [Verify a Bank Account](https://lob.com/docs/php#bankaccounts_verify)
     - [List all Bank Accounts](https://lob.com/docs/php#bankaccounts_list)
-- **Prints API**
-  - [Jobs](https://lob.com/docs/php#jobs)
-    - [Create a Job](https://lob.com/docs/php#jobs_create)
-    - [Create a MultiObject Job](https://lob.com/docs/php#jobs_multi)
-    - [Retrieve a Job](https://lob.com/docs/php#jobs_retrieve)
-    - [List all Jobs](https://lob.com/docs/php#jobs_list)
-  - [Objects](https://lob.com/docs/php#objects)
-    - [Create an Object](https://lob.com/docs/php#objects_create)
-    - [Retrieve an Object](https://lob.com/docs/php#objects_retrieve)
-    - [Delete an Object](https://lob.com/docs/php#objects_delete)
-    - [List all Objects](https://lob.com/docs/php#objects_list)
-  - [Settings](https://lob.com/docs/php#settings)
-    - [Retrieve a Setting](https://lob.com/docs/php#settings_retrieve)
-    - [List all Settings](https://lob.com/docs/php#settings_list)
 - **Area Mail API**
   - [Areas](https://lob.com/docs/php#areas)
     - [Create an Area Mailing](https://lob.com/docs/php#areas_create)
@@ -129,7 +114,6 @@ We've provided various examples for you to try out [here](https://github.com/lob
   - [API Changelog](https://lob.com/docs/php#changelog)
   - [HTML Examples](https://lob.com/docs/php#html-examples)
   - [Image Prepping](https://lob.com/docs/php#prepping)
-  - [Prints API Templates](https://lob.com/docs/php#prints-templates)
 
 ## Testing
 


### PR DESCRIPTION
just removing broken links for now. we can update the actual wrappers' contents whenever we release the version deprecating jobs.