### PR TITLE
fix(errors): catch all 500s as internal server errors

### DIFF
--- a/src/Lob/Resource.php
+++ b/src/Lob/Resource.php
@@ -127,8 +127,8 @@ abstract class Resource implements ResourceInterface
 
             // @codeCoverageIgnoreStart
             // must induce serverside error to test this, so not testable
-            if ($statusCode === 500)
-                throw new InternalErrorException($errorMessage, 500);
+            if ($statusCode >= 500)
+                throw new InternalErrorException($errorMessage, $statusCode);
             // @codeCoverageIgnoreEnd
 
             // @codeCoverageIgnoreStart


### PR DESCRIPTION
##### What

- [x] throw an `InternalErrorException` for responses with status codes 500+.

##### Why

So that the user can catch and react to any 5XX and not purely just an HTTP 500.