### PR TITLE
feat(routes): allow fetching of individual routes

### DIFF
--- a/src/Lob/Resource/Routes.php
+++ b/src/Lob/Resource/Routes.php
@@ -16,11 +16,6 @@ use Lob\Resource as ResourceBase;
 
 class Routes extends ResourceBase
 {
-    public function get($id)
-    {
-        throw new BadMethodCallException(__CLASS__.'::'.__FUNCTION__.'() is not supported.');
-    }
-
     public function create(array $data)
     {
         throw new BadMethodCallException(__CLASS__.'::'.__FUNCTION__.'() is not supported.');

--- a/tests/Lob/Tests/Resource/RoutesTest.php
+++ b/tests/Lob/Tests/Resource/RoutesTest.php
@@ -30,20 +30,19 @@ class RoutesTest extends \Lob\Tests\ResourceTest
         $this->assertTrue(is_array($routes));
     }
 
+    public function testGet()
+    {
+        $route = $this->resource->get('94158-C002');
+
+        $this->assertTrue(is_array($route));
+    }
+
     /**
     * @expectedException BadMethodCallException
     */
     public function testCreateFail()
     {
       $create = $this->resource->create(array());
-    }
-
-    /**
-    * @expectedException BadMethodCallException
-    */
-    public function testGetFail()
-    {
-        $create = $this->resource->get('1');
     }
 
     /**


### PR DESCRIPTION
## What & Why
For some reason we didn't have individual routes `/v1/routes/{id}` enabled in our wrapper. This PR enables it. It was already coded, we were just overwriting it.