### PR TITLE
chore(version): bump client version

### DIFF
--- a/src/Lob/Lob.php
+++ b/src/Lob/Lob.php
@@ -36,7 +36,7 @@ class Lob
             $this->setApiKey($apiKey);
         }
         $this->version = $version;
-        $this->clientVersion = '1.5.0';
+        $this->clientVersion = '1.7.1';
     }
 
     public function getApiKey()


### PR DESCRIPTION
## What & Why
I just realized we haven't updated our client version in a while (a couple of releases). This value is used in each request when setting the User-Agent to let us know what version of the PHP wrapper customers are using. Once this is merged, I'll cut a new tag version (`v1.7.1`).