### PR TITLE
feat(versions): Support PHP 7.1 and remove support for 5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: php
 dist: trusty
 php:
-  - 5.5
   - 5.6
   - 7.0
+  - 7.1
   - hhvm
 before_install:
   - composer selfupdate


### PR DESCRIPTION
-[x] Supports PHP 7.1, and removes support for 5.5, which has been deprecated since early 2016.