### PR TITLE
fix(resource): clean up resource and 100% coverage

### DIFF
--- a/src/Lob/Exception/AuthorizationException.php
+++ b/src/Lob/Exception/AuthorizationException.php
@@ -1,14 +1,5 @@
 <?php
 
-/*
- * This file is part of the Lob.com PHP Client.
- *
- * (c) 2013 Lob.com, https://www.lob.com
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Lob\Exception;
 
 use Exception;

--- a/src/Lob/Exception/ForbiddenException.php
+++ b/src/Lob/Exception/ForbiddenException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Lob\Exception;
+
+use Exception;
+
+class ForbiddenException extends Exception { }

--- a/src/Lob/Exception/InternalErrorException.php
+++ b/src/Lob/Exception/InternalErrorException.php
@@ -1,14 +1,5 @@
 <?php
 
-/*
- * This file is part of the Lob.com PHP Client.
- *
- * (c) 2013 Lob.com, https://www.lob.com
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Lob\Exception;
 
 use Exception;

--- a/src/Lob/Exception/NetworkErrorException.php
+++ b/src/Lob/Exception/NetworkErrorException.php
@@ -1,14 +1,5 @@
 <?php
 
-/*
- * This file is part of the Lob.com PHP Client.
- *
- * (c) 2013 Lob.com, https://www.lob.com
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Lob\Exception;
 
 use Exception;

--- a/src/Lob/Exception/RateLimitException.php
+++ b/src/Lob/Exception/RateLimitException.php
@@ -1,14 +1,5 @@
 <?php
 
-/*
- * This file is part of the Lob.com PHP Client.
- *
- * (c) 2013 Lob.com, https://www.lob.com
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Lob\Exception;
 
 use Exception;

--- a/src/Lob/Exception/ResourceNotFoundException.php
+++ b/src/Lob/Exception/ResourceNotFoundException.php
@@ -1,14 +1,5 @@
 <?php
 
-/*
- * This file is part of the Lob.com PHP Client.
- *
- * (c) 2013 Lob.com, https://www.lob.com
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Lob\Exception;
 
 use Exception;

--- a/src/Lob/Exception/UnexpectedErrorException.php
+++ b/src/Lob/Exception/UnexpectedErrorException.php
@@ -1,14 +1,5 @@
 <?php
 
-/*
- * This file is part of the Lob.com PHP Client.
- *
- * (c) 2013 Lob.com, https://www.lob.com
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Lob\Exception;
 
 use Exception;

--- a/src/Lob/Exception/ValidationException.php
+++ b/src/Lob/Exception/ValidationException.php
@@ -1,14 +1,5 @@
 <?php
 
-/*
- * This file is part of the Lob.com PHP Client.
- *
- * (c) 2013 Lob.com, https://www.lob.com
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Lob\Exception;
 
 use Exception;

--- a/src/Lob/Lob.php
+++ b/src/Lob/Lob.php
@@ -1,14 +1,5 @@
 <?php
 
-/*
- * This file is part of the Lob.com PHP Client.
- *
- * (c) 2013 Lob.com, https://www.lob.com
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Lob;
 
 use InvalidArgumentException;

--- a/src/Lob/Resource/Addresses.php
+++ b/src/Lob/Resource/Addresses.php
@@ -1,14 +1,5 @@
 <?php
 
-/*
- * This file is part of the Lob.com PHP Client.
- *
- * (c) 2013 Lob.com, https://www.lob.com
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Lob\Resource;
 
 use Lob\Resource as ResourceBase;

--- a/src/Lob/Resource/Areas.php
+++ b/src/Lob/Resource/Areas.php
@@ -1,14 +1,5 @@
 <?php
 
-/*
- * This file is part of the Lob.com PHP Client.
- *
- * (c) 2013 Lob.com, https://www.lob.com
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Lob\Resource;
 
 use BadMethodCallException;

--- a/src/Lob/Resource/BankAccounts.php
+++ b/src/Lob/Resource/BankAccounts.php
@@ -13,8 +13,6 @@ class BankAccounts extends ResourceBase
   function verify($id, $amounts) {
     return $this->sendRequest(
         'POST',
-        $this->lob->getVersion(),
-        $this->lob->getClientVersion(),
         $this->resourceName().'/'.strval($id).'/verify',
         array(),
         array(

--- a/src/Lob/Resource/Checks.php
+++ b/src/Lob/Resource/Checks.php
@@ -1,14 +1,5 @@
 <?php
 
-/*
- * This file is part of the Lob.com PHP Client.
- *
- * (c) 2013 Lob.com, https://www.lob.com
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Lob\Resource;
 
 use Lob\Resource as ResourceBase;

--- a/src/Lob/Resource/IntlVerifications.php
+++ b/src/Lob/Resource/IntlVerifications.php
@@ -1,14 +1,5 @@
 <?php
 
-/*
- * This file is part of the Lob.com PHP Client.
- *
- * (c) 2013 Lob.com, https://www.lob.com
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Lob\Resource;
 
 use Lob\Resource as ResourceBase;
@@ -20,8 +11,6 @@ class IntlVerifications extends ResourceBase
     {
         return $this->sendRequest(
             'POST',
-            $this->lob->getVersion(),
-            $this->lob->getClientVersion(),
             'intl_verifications',
             array(),
             $data

--- a/src/Lob/Resource/Letters.php
+++ b/src/Lob/Resource/Letters.php
@@ -1,14 +1,5 @@
 <?php
 
-/*
- * This file is part of the Lob.com PHP Client.
- *
- * (c) 2013 Lob.com, https://www.lob.com
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Lob\Resource;
 
 use Lob\Resource as ResourceBase;

--- a/src/Lob/Resource/Postcards.php
+++ b/src/Lob/Resource/Postcards.php
@@ -1,14 +1,5 @@
 <?php
 
-/*
- * This file is part of the Lob.com PHP Client.
- *
- * (c) 2013 Lob.com, https://www.lob.com
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Lob\Resource;
 
 use Lob\Resource as ResourceBase;

--- a/src/Lob/Resource/Routes.php
+++ b/src/Lob/Resource/Routes.php
@@ -1,14 +1,5 @@
 <?php
 
-/*
- * This file is part of the Lob.com PHP Client.
- *
- * (c) 2013 Lob.com, https://www.lob.com
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Lob\Resource;
 
 use BadMethodCallException;

--- a/src/Lob/Resource/USVerifications.php
+++ b/src/Lob/Resource/USVerifications.php
@@ -1,14 +1,5 @@
 <?php
 
-/*
- * This file is part of the Lob.com PHP Client.
- *
- * (c) 2013 Lob.com, https://www.lob.com
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Lob\Resource;
 
 use Lob\Resource as ResourceBase;
@@ -20,8 +11,6 @@ class USVerifications extends ResourceBase
     {
         return $this->sendRequest(
             'POST',
-            $this->lob->getVersion(),
-            $this->lob->getClientVersion(),
             'us_verifications',
             array(),
             $data

--- a/src/Lob/Resource/USZipLookups.php
+++ b/src/Lob/Resource/USZipLookups.php
@@ -1,14 +1,5 @@
 <?php
 
-/*
- * This file is part of the Lob.com PHP Client.
- *
- * (c) 2013 Lob.com, https://www.lob.com
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Lob\Resource;
 
 use Lob\Resource as ResourceBase;
@@ -20,8 +11,6 @@ class USZipLookups extends ResourceBase
     {
         return $this->sendRequest(
             'POST',
-            $this->lob->getVersion(),
-            $this->lob->getClientVersion(),
             'us_zip_lookups',
             array(),
             $data

--- a/src/Lob/ResourceInterface.php
+++ b/src/Lob/ResourceInterface.php
@@ -1,19 +1,10 @@
 <?php
 
-/*
- * This file is part of the Lob.com PHP Client.
- *
- * (c) 2013 Lob.com, https://www.lob.com
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Lob;
 
 interface ResourceInterface
 {
-    public function all(array $options = array(), $includeMeta = false);
+    public function all(array $options = array());
     public function create(array $data);
     public function get($id);
     public function delete($id);

--- a/tests/Lob/Tests/LobTest.php
+++ b/tests/Lob/Tests/LobTest.php
@@ -1,14 +1,5 @@
 <?php
 
-/*
- * This file is part of the Lob.com PHP Client.
- *
- * (c) 2013 Lob.com, https://www.lob.com
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace Lob\Tests;
 
 use InvalidArgumentException;
@@ -38,7 +29,7 @@ class LobTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->lob = new Lob('test_7c5d111af5ccfedb9f0eea91745c93896a1');
+        $this->lob = new Lob(LOB_TEST_API_KEY);
     }
 
     public function testVersionDefaultValueIsNull()
@@ -108,6 +99,18 @@ class LobTest extends \PHPUnit_Framework_TestCase
     {
         $this->setExpectedException('InvalidArgumentException');
         $this->lob->setApiKey(null);
+    }
+
+    public function testSpecificApiVersion()
+    {
+      $lob = new Lob(LOB_TEST_API_KEY, "2017-11-08");
+      $this->assertEquals($lob->getVersion(), "2017-11-08");
+
+      $verification = $lob->usVerifications()->verify(array(
+          "primary_line" => "185 BERRY ST",
+          "zip_code" => "94107"
+      ));
+      $this->assertTrue(is_array($verification));
     }
 
 }

--- a/tests/Lob/Tests/LobTest.php
+++ b/tests/Lob/Tests/LobTest.php
@@ -87,7 +87,7 @@ class LobTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($this->lob->usZipLookups() instanceof USZipLookups);
     }
 
-    public function testSetApiKeyMethodSetsApiKey()
+    public function testSetApiKey()
     {
         $oldApiKey = $this->lob->getApiKey();
         $this->lob->setApiKey("hello world");
@@ -95,10 +95,24 @@ class LobTest extends \PHPUnit_Framework_TestCase
         $this->lob->setApiKey($oldApiKey);
     }
 
-    public function testSetApiKeyMethodWithBadApiKey()
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testSetNullApiKey()
     {
-        $this->setExpectedException('InvalidArgumentException');
         $this->lob->setApiKey(null);
+    }
+
+    /**
+     * @expectedException Lob\Exception\AuthorizationException
+     */
+    public function testInvalidApiKey()
+    {
+        $lob = new Lob("bad_api_key");
+        $lob->usVerifications()->verify(array(
+            "primary_line" => "185 BERRY ST",
+            "zip_code" => "94107"
+        ));
     }
 
     public function testSpecificApiVersion()

--- a/tests/Lob/Tests/Resource/AddressesTest.php
+++ b/tests/Lob/Tests/Resource/AddressesTest.php
@@ -1,14 +1,5 @@
 <?php
 
-/*
- * This file is part of the Lob.com PHP Client.
- *
- * (c) 2013 Lob.com, https://www.lob.com
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 use Lob\Lob;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Lob/Tests/Resource/IntlVerificationsTest.php
+++ b/tests/Lob/Tests/Resource/IntlVerificationsTest.php
@@ -1,14 +1,5 @@
 <?php
 
-/*
- * This file is part of the Lob.com PHP Client.
- *
- * (c) 2013 Lob.com, https://www.lob.com
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 use Lob\Lob;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Lob/Tests/Resource/IntlVerificationsTest.php
+++ b/tests/Lob/Tests/Resource/IntlVerificationsTest.php
@@ -18,7 +18,7 @@ class IntlVerificationsTest extends TestCase
     }
 
     /**
-     * @expectedException Lob\Exception\AuthorizationException
+     * @expectedException Lob\Exception\ForbiddenException
      */
     public function testVerify()
     {

--- a/tests/Lob/Tests/Resource/LettersTest.php
+++ b/tests/Lob/Tests/Resource/LettersTest.php
@@ -1,14 +1,5 @@
 <?php
 
-/*
- * This file is part of the Lob.com PHP Client.
- *
- * (c) 2013 Lob.com, https://www.lob.com
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 use Lob\Lob;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Lob/Tests/Resource/PostcardsTest.php
+++ b/tests/Lob/Tests/Resource/PostcardsTest.php
@@ -1,14 +1,5 @@
 <?php
 
-/*
- * This file is part of the Lob.com PHP Client.
- *
- * (c) 2013 Lob.com, https://www.lob.com
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 use Lob\Lob;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Lob/Tests/Resource/RoutesTest.php
+++ b/tests/Lob/Tests/Resource/RoutesTest.php
@@ -1,14 +1,5 @@
 <?php
 
-/*
- * This file is part of the Lob.com PHP Client.
- *
- * (c) 2013 Lob.com, https://www.lob.com
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 use Lob\Lob;
 use PHPUnit\Framework\TestCase;
 

--- a/tests/Lob/Tests/Resource/USVerificationsTest.php
+++ b/tests/Lob/Tests/Resource/USVerificationsTest.php
@@ -1,14 +1,5 @@
 <?php
 
-/*
- * This file is part of the Lob.com PHP Client.
- *
- * (c) 2013 Lob.com, https://www.lob.com
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 use Lob\Lob;
 use PHPUnit\Framework\TestCase;
 
@@ -32,6 +23,14 @@ class USVerificationsTest extends TestCase
 
         $this->assertTrue(is_array($verifiedAddress));
         $this->assertTrue(array_key_exists('id', $verifiedAddress));
+    }
+
+    /**
+     * @expectedException Lob\Exception\ValidationException
+     */
+    public function testUnprocessibleEntity()
+    {
+        $this->lob->usVerifications()->verify(array());
     }
 
     /**

--- a/tests/Lob/Tests/Resource/USZipLookupsTest.php
+++ b/tests/Lob/Tests/Resource/USZipLookupsTest.php
@@ -1,15 +1,5 @@
 <?php
 
-/*
- * This file is part of the Lob.com PHP Client.
- *
- * (c) 2013 Lob.com, https://www.lob.com
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
-
 use Lob\Lob;
 use PHPUnit\Framework\TestCase;
 


### PR DESCRIPTION
- [x] Removes some unnecessary parts of code (comments, `$includeMeta` param to `all` method, and excessive exceptions)
- [x] Adds tests for specifying an API version to get up to 100% code coverage