### PR TITLE
fix(resource): better handling of import files

### DIFF
--- a/src/Lob/Resource.php
+++ b/src/Lob/Resource.php
@@ -30,6 +30,8 @@ abstract class Resource implements ResourceInterface
 
     protected $client;
 
+    private static $file_parameters = array('front', 'back', 'file', 'check_bottom', 'attachment');
+
     public function __construct(Lob $lob)
     {
         $this->lob = $lob;
@@ -170,7 +172,7 @@ abstract class Resource implements ResourceInterface
                 'contents' => $value
             );
 
-            if ((is_string($value) && strpos($value, '@') === 0)) {
+            if (in_array($key, self::$file_parameters) && (is_string($value) && strpos($value, '@') === 0)) {
                 $element['contents'] = fopen(substr($value, 1), 'r');
             }
 


### PR DESCRIPTION
**What**
- [x] Only considers files if the `key` is one of`array('front', 'back', 'file', 'check_bottom', 'attachment')`

**Context**
As mentioned in #83, some people us the @ symbol in order to indicate "care of" section of an address. Currently the library interprets strings starting with `@` as files that need to be included in the request therefore a value of `@ DE ZIMMERMANN` will try to open the local file ` DE ZIMMERMANN` and err out.

Fixes #83