### PR TITLE
Check for response before trying to use it.

### DIFF
--- a/src/Lob/Resource.php
+++ b/src/Lob/Resource.php
@@ -93,6 +93,10 @@ abstract class Resource implements ResourceInterface
             throw new NetworkErrorException($e->getMessage());
             // @codeCoverageIgnoreEnd
         } catch (GuzzleException $e) {
+            if (!$e->hasResponse()) {
+                throw new UnexpectedErrorException('An Unexpected Error has occurred: ' . $e->getMessage());
+            }
+            
             $responseErrorBody = strval($e->getResponse()->getBody());
             $errorMessage = $this->errorMessageFromJsonBody($responseErrorBody);
             $statusCode = $e->getResponse()->getStatusCode();


### PR DESCRIPTION
Fixes #85. 

`getResponse()` can and does return `null` sometimes, so calling `getBody()` on it blindly can cause errors.