### PR TITLE
chore(resource): rename Resoruce to ResourceBase

### DIFF
--- a/src/Lob/Lob.php
+++ b/src/Lob/Lob.php
@@ -4,7 +4,7 @@ namespace Lob;
 
 use InvalidArgumentException;
 use BadMethodCallException;
-use Lob\Resource;
+use Lob\LobResource;
 use Lob\Resource\Addresses;
 use Lob\Resource\Areas;
 use Lob\Resource\BankAccounts;

--- a/src/Lob/Lob.php
+++ b/src/Lob/Lob.php
@@ -4,7 +4,7 @@ namespace Lob;
 
 use InvalidArgumentException;
 use BadMethodCallException;
-use Lob\LobResource;
+use Lob\ResourceBase;
 use Lob\Resource\Addresses;
 use Lob\Resource\Areas;
 use Lob\Resource\BankAccounts;

--- a/src/Lob/LobResource.php
+++ b/src/Lob/LobResource.php
@@ -24,7 +24,7 @@ use Lob\Exception\UnexpectedErrorException;
 use Lob\Exception\ValidationException;
 use Lob\Exception\RateLimitException;
 
-abstract class Resource implements ResourceInterface
+abstract class LobResource implements ResourceInterface
 {
     protected $lob;
 
@@ -96,7 +96,7 @@ abstract class Resource implements ResourceInterface
             if (!$e->hasResponse()) {
                 throw new UnexpectedErrorException('An Unexpected Error has occurred: ' . $e->getMessage());
             }
-            
+
             $responseErrorBody = strval($e->getResponse()->getBody());
             $errorMessage = $this->errorMessageFromJsonBody($responseErrorBody);
             $statusCode = $e->getResponse()->getStatusCode();

--- a/src/Lob/Resource/Addresses.php
+++ b/src/Lob/Resource/Addresses.php
@@ -2,7 +2,7 @@
 
 namespace Lob\Resource;
 
-use Lob\LobResource as ResourceBase;
+use Lob\ResourceBase;
 
 class Addresses extends ResourceBase
 {

--- a/src/Lob/Resource/Addresses.php
+++ b/src/Lob/Resource/Addresses.php
@@ -2,7 +2,7 @@
 
 namespace Lob\Resource;
 
-use Lob\Resource as ResourceBase;
+use Lob\LobResource as ResourceBase;
 
 class Addresses extends ResourceBase
 {

--- a/src/Lob/Resource/Areas.php
+++ b/src/Lob/Resource/Areas.php
@@ -2,8 +2,8 @@
 
 namespace Lob\Resource;
 
+use Lob\LobResource as ResourceBase;
 use BadMethodCallException;
-use Lob\Resource as ResourceBase;
 
 class Areas extends ResourceBase
 {

--- a/src/Lob/Resource/Areas.php
+++ b/src/Lob/Resource/Areas.php
@@ -2,7 +2,7 @@
 
 namespace Lob\Resource;
 
-use Lob\LobResource as ResourceBase;
+use Lob\ResourceBase;
 use BadMethodCallException;
 
 class Areas extends ResourceBase

--- a/src/Lob/Resource/BankAccounts.php
+++ b/src/Lob/Resource/BankAccounts.php
@@ -2,7 +2,7 @@
 
 namespace Lob\Resource;
 
-use Lob\LobResource as ResourceBase;
+use Lob\ResourceBase;
 
 class BankAccounts extends ResourceBase
 {

--- a/src/Lob/Resource/BankAccounts.php
+++ b/src/Lob/Resource/BankAccounts.php
@@ -2,7 +2,7 @@
 
 namespace Lob\Resource;
 
-use Lob\Resource as ResourceBase;
+use Lob\LobResource as ResourceBase;
 
 class BankAccounts extends ResourceBase
 {

--- a/src/Lob/Resource/Checks.php
+++ b/src/Lob/Resource/Checks.php
@@ -2,7 +2,7 @@
 
 namespace Lob\Resource;
 
-use Lob\Resource as ResourceBase;
+use Lob\LobResource as ResourceBase;
 
 class Checks extends ResourceBase
 {

--- a/src/Lob/Resource/Checks.php
+++ b/src/Lob/Resource/Checks.php
@@ -2,7 +2,7 @@
 
 namespace Lob\Resource;
 
-use Lob\LobResource as ResourceBase;
+use Lob\ResourceBase;
 
 class Checks extends ResourceBase
 {

--- a/src/Lob/Resource/IntlVerifications.php
+++ b/src/Lob/Resource/IntlVerifications.php
@@ -2,7 +2,7 @@
 
 namespace Lob\Resource;
 
-use Lob\Resource as ResourceBase;
+use Lob\LobResource as ResourceBase;
 use BadMethodCallException;
 
 class IntlVerifications extends ResourceBase

--- a/src/Lob/Resource/IntlVerifications.php
+++ b/src/Lob/Resource/IntlVerifications.php
@@ -2,7 +2,7 @@
 
 namespace Lob\Resource;
 
-use Lob\LobResource as ResourceBase;
+use Lob\ResourceBase;
 use BadMethodCallException;
 
 class IntlVerifications extends ResourceBase

--- a/src/Lob/Resource/Letters.php
+++ b/src/Lob/Resource/Letters.php
@@ -2,7 +2,7 @@
 
 namespace Lob\Resource;
 
-use Lob\LobResource as ResourceBase;
+use Lob\ResourceBase;
 
 class Letters extends ResourceBase
 {

--- a/src/Lob/Resource/Letters.php
+++ b/src/Lob/Resource/Letters.php
@@ -2,7 +2,7 @@
 
 namespace Lob\Resource;
 
-use Lob\Resource as ResourceBase;
+use Lob\LobResource as ResourceBase;
 
 class Letters extends ResourceBase
 {

--- a/src/Lob/Resource/Postcards.php
+++ b/src/Lob/Resource/Postcards.php
@@ -2,7 +2,7 @@
 
 namespace Lob\Resource;
 
-use Lob\Resource as ResourceBase;
+use Lob\LobResource as ResourceBase;
 
 class Postcards extends ResourceBase
 {

--- a/src/Lob/Resource/Postcards.php
+++ b/src/Lob/Resource/Postcards.php
@@ -2,7 +2,7 @@
 
 namespace Lob\Resource;
 
-use Lob\LobResource as ResourceBase;
+use Lob\ResourceBase;
 
 class Postcards extends ResourceBase
 {

--- a/src/Lob/Resource/Routes.php
+++ b/src/Lob/Resource/Routes.php
@@ -2,8 +2,8 @@
 
 namespace Lob\Resource;
 
+use Lob\LobResource as ResourceBase;
 use BadMethodCallException;
-use Lob\Resource as ResourceBase;
 
 class Routes extends ResourceBase
 {

--- a/src/Lob/Resource/Routes.php
+++ b/src/Lob/Resource/Routes.php
@@ -2,7 +2,7 @@
 
 namespace Lob\Resource;
 
-use Lob\LobResource as ResourceBase;
+use Lob\ResourceBase;
 use BadMethodCallException;
 
 class Routes extends ResourceBase

--- a/src/Lob/Resource/USVerifications.php
+++ b/src/Lob/Resource/USVerifications.php
@@ -2,7 +2,7 @@
 
 namespace Lob\Resource;
 
-use Lob\Resource as ResourceBase;
+use Lob\LobResource as ResourceBase;
 use BadMethodCallException;
 
 class USVerifications extends ResourceBase

--- a/src/Lob/Resource/USVerifications.php
+++ b/src/Lob/Resource/USVerifications.php
@@ -2,7 +2,7 @@
 
 namespace Lob\Resource;
 
-use Lob\LobResource as ResourceBase;
+use Lob\ResourceBase;
 use BadMethodCallException;
 
 class USVerifications extends ResourceBase

--- a/src/Lob/Resource/USZipLookups.php
+++ b/src/Lob/Resource/USZipLookups.php
@@ -2,7 +2,7 @@
 
 namespace Lob\Resource;
 
-use Lob\Resource as ResourceBase;
+use Lob\LobResource as ResourceBase;
 use BadMethodCallException;
 
 class USZipLookups extends ResourceBase

--- a/src/Lob/Resource/USZipLookups.php
+++ b/src/Lob/Resource/USZipLookups.php
@@ -2,7 +2,7 @@
 
 namespace Lob\Resource;
 
-use Lob\LobResource as ResourceBase;
+use Lob\ResourceBase;
 use BadMethodCallException;
 
 class USZipLookups extends ResourceBase

--- a/src/Lob/ResourceBase.php
+++ b/src/Lob/ResourceBase.php
@@ -24,7 +24,7 @@ use Lob\Exception\UnexpectedErrorException;
 use Lob\Exception\ValidationException;
 use Lob\Exception\RateLimitException;
 
-abstract class LobResource implements ResourceInterface
+abstract class ResourceBase implements ResourceInterface
 {
     protected $lob;
 


### PR DESCRIPTION
**What & Why**
- [x] Rename internal `Resource` class to `ResourceBase`
  - It seems hhvm has `Resource` as a reserved class name. That being said, I'm not sure why this wasn't an issue until today.