### PR TITLE
Change method signature to match ResourceBase

### DIFF
--- a/src/Lob/Resource/IntlVerifications.php
+++ b/src/Lob/Resource/IntlVerifications.php
@@ -22,7 +22,7 @@ class IntlVerifications extends ResourceBase
         throw new BadMethodCallException(__CLASS__.'::'.__FUNCTION__.'() is not supported.');
     }
 
-    public function create(array $data)
+    public function create(array $data, array $headers = null)
     {
         throw new BadMethodCallException(__CLASS__.'::'.__FUNCTION__.'() is not supported.');
     }


### PR DESCRIPTION
This is to fix the following error: `Declaration of Lob\Resource\IntlVerifications::create(array $data) must be compatible with Lob\ResourceBase::create(array $data, ?array $headers = NULL)`