### PR TITLE
fix(rescource-create): standardize resource create methods

### DIFF
--- a/src/Lob/Resource/Routes.php
+++ b/src/Lob/Resource/Routes.php
@@ -7,7 +7,7 @@ use BadMethodCallException;
 
 class Routes extends ResourceBase
 {
-    public function create(array $data)
+    public function create(array $data, array $headers = null)
     {
         throw new BadMethodCallException(__CLASS__.'::'.__FUNCTION__.'() is not supported.');
     }

--- a/src/Lob/Resource/USZipLookups.php
+++ b/src/Lob/Resource/USZipLookups.php
@@ -22,7 +22,7 @@ class USZipLookups extends ResourceBase
         throw new BadMethodCallException(__CLASS__.'::'.__FUNCTION__.'() is not supported.');
     }
 
-    public function create(array $data)
+    public function create(array $data, array $headers = null)
     {
         throw new BadMethodCallException(__CLASS__.'::'.__FUNCTION__.'() is not supported.');
     }

--- a/src/Lob/ResourceInterface.php
+++ b/src/Lob/ResourceInterface.php
@@ -5,7 +5,7 @@ namespace Lob;
 interface ResourceInterface
 {
     public function all(array $options = array());
-    public function create(array $data);
+    public function create(array $data, array $headers = null);
     public function get($id);
     public function delete($id);
 }


### PR DESCRIPTION
**What**

* Adds `$headers` arguments to all `create` methods that are overridden on resources.
* Makes the resource interface consistent with the resource base class.

**Note**

Merge this after #95 