### PR TITLE
chore(intl-ver): update intl ver test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ php:
   - 5.6
   - 7.0
   - 7.1
-  - hhvm
+  - 7.2
 before_install:
   - composer selfupdate
   - composer install

--- a/tests/Lob/Tests/Resource/IntlVerificationsTest.php
+++ b/tests/Lob/Tests/Resource/IntlVerificationsTest.php
@@ -17,12 +17,12 @@ class IntlVerificationsTest extends TestCase
         );
     }
 
-    /**
-     * @expectedException Lob\Exception\ForbiddenException
-     */
     public function testVerify()
     {
-        $this->lob->intlVerifications()->verify($this->intlAddress);
+        $verifiedAddress = $this->lob->intlVerifications()->verify($this->intlAddress);
+
+        $this->assertTrue(is_array($verifiedAddress));
+        $this->assertTrue(array_key_exists('id', $verifiedAddress));
     }
 
     /**


### PR DESCRIPTION
## What & Why

With the introduction of our International Verifications Test Mode, we need to update this test to ensure that we get a valid response.