### PR TITLE
Allow Guzzle 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     }],
     "require": {
         "php": ">=5.6.0",
-        "guzzlehttp/guzzle": "~6.0"
+        "guzzlehttp/guzzle": "~6.0|~7.0"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
As of now, this package can't be using Laravel 8 which has Guzzle 7 as requirement.

Guzzle 7 has no breaking changes that impact this package.