### PR TITLE
chore: remove API keys from tests and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ composer install       # For PHP >= 7.0
 Once the dependencies have been installed, the tests can be run with
 
 ```
-php vendor/bin/phpunit
+LOB_API_KEY=<YOUR_API_KEY_HERE> php vendor/bin/phpunit
 ```
 
 To get a code coverage report after running the test suite, run

--- a/examples/README.md
+++ b/examples/README.md
@@ -18,7 +18,7 @@ In order to run the program enter:
 
 ```
 cd create_postcards_from_csv/
-php create_postcards_from_csv.php input.csv
+LOB_API_KEY=<YOUR_API_KEY_HERE> php create_postcards_from_csv.php input.csv
 ```
 
 ### Verify US addresses from CSV
@@ -29,20 +29,20 @@ Please note that if you are running this with a Test API Key, the verification A
 
 ```
 cd verify_addresses_from_csv/
-php verify.php input.csv
+LOB_API_KEY=<YOUR_API_KEY_HERE> php verify.php input.csv
 ```
 
 ### Create a check
 ```
-php create_check.php
+LOB_API_KEY=<YOUR_API_KEY_HERE> php create_check.php
 ```
 
 ### Create a letter
 ```
-php create_letter.php
+LOB_API_KEY=<YOUR_API_KEY_HERE> php create_letter.php
 ```
 
 ### Create a postcard
 ```
-php create_postcard.php
+LOB_API_KEY=<YOUR_API_KEY_HERE> php create_postcard.php
 ```

--- a/examples/create_check.php
+++ b/examples/create_check.php
@@ -1,7 +1,7 @@
 <?php
 require '../vendor/autoload.php';
 
-$lob = new \Lob\Lob('test_7c5d111af5ccfedb9f0eea91745c93896a1');
+$lob = new \Lob\Lob(getenv('LOB_API_KEY'));
 
 $from_address = $lob->addresses()->create(array(
   'name' => 'Jane Doe',

--- a/examples/create_letter.php
+++ b/examples/create_letter.php
@@ -1,7 +1,7 @@
 <?php
 require '../vendor/autoload.php';
 
-$lob = new \Lob\Lob('test_7c5d111af5ccfedb9f0eea91745c93896a1');
+$lob = new \Lob\Lob(getenv('LOB_API_KEY'));
 
 $from_address = $lob->addresses()->create(array(
   'name'          => 'Lob.com',

--- a/examples/create_postcard.php
+++ b/examples/create_postcard.php
@@ -3,7 +3,7 @@ require '../vendor/autoload.php';
 
 $file = file_get_contents('html/card.html');
 
-$lob = new \Lob\Lob('test_7c5d111af5ccfedb9f0eea91745c93896a1');
+$lob = new \Lob\Lob(getenv('LOB_API_KEY'));
 
 $to_address = $lob->addresses()->create(array(
   'name'          => 'Lob.com',

--- a/examples/create_postcards_from_csv/create_postcards_from_csv.php
+++ b/examples/create_postcards_from_csv/create_postcards_from_csv.php
@@ -12,7 +12,7 @@ $handle = fopen($argv[1], "r");
 $html_front = file_get_contents('postcard_front.html');
 $html_back = file_get_contents('postcard_back.html');
 
-$lob = new \Lob\Lob('test_7c5d111af5ccfedb9f0eea91745c93896a1');
+$lob = new \Lob\Lob(getenv('LOB_API_KEY'));
 
 $from_address = $lob->addresses()->create(array(
   'name'          => 'The Big House',

--- a/examples/verify_addresses_from_csv/verify.php
+++ b/examples/verify_addresses_from_csv/verify.php
@@ -8,7 +8,7 @@
 
 require '../../vendor/autoload.php';
 
-$lob = new \Lob\Lob('test_7c5d111af5ccfedb9f0eea91745c93896a1');
+$lob = new \Lob\Lob(getenv('LOB_API_KEY'));
 
 $handle = fopen($argv[1], "r");
 $output_file = fopen("output.csv","w");

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,10 +9,6 @@
          convertWarningsToExceptions="true"
          testSuiteLoaderClass="PHPUnit_Runner_StandardTestSuiteLoader">
 
-    <php>
-        <const name="LOB_TEST_API_KEY" value="test_7c5d111af5ccfedb9f0eea91745c93896a1"/>
-    </php>
-
     <testsuites>
         <testsuite>
             <directory>./tests/Lob/Tests</directory>

--- a/tests/Lob/Tests/LobTest.php
+++ b/tests/Lob/Tests/LobTest.php
@@ -27,7 +27,7 @@ class LobTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->lob = new Lob(LOB_TEST_API_KEY);
+        $this->lob = new Lob(getenv('LOB_API_KEY'));
     }
 
     public function testVersionDefaultValueIsNull()
@@ -105,7 +105,7 @@ class LobTest extends \PHPUnit_Framework_TestCase
 
     public function testSpecificApiVersion()
     {
-      $lob = new Lob(LOB_TEST_API_KEY, "2017-11-08");
+      $lob = new Lob(getenv('LOB_API_KEY'), "2017-11-08");
       $this->assertEquals($lob->getVersion(), "2017-11-08");
     }
 

--- a/tests/Lob/Tests/Resource/AddressesTest.php
+++ b/tests/Lob/Tests/Resource/AddressesTest.php
@@ -7,7 +7,7 @@ class AddressesTest extends TestCase
 {
     protected function setUp()
     {
-        $this->lob = new Lob(LOB_TEST_API_KEY);
+        $this->lob = new Lob(getenv('LOB_API_KEY'));
         $this->addressParams = array(
             'name' => 'Larry Lobster',
             'address_line1' => '185 Berry St',

--- a/tests/Lob/Tests/Resource/BankAccountsTest.php
+++ b/tests/Lob/Tests/Resource/BankAccountsTest.php
@@ -7,7 +7,7 @@ class BankAccountsTest extends TestCase
 {
     protected function setUp()
     {
-        $this->lob = new Lob(LOB_TEST_API_KEY);
+        $this->lob = new Lob(getenv('LOB_API_KEY'));
         $this->bankData = array(
             'routing_number' => 322271627,
             'account_number' => 123456789,

--- a/tests/Lob/Tests/Resource/ChecksTest.php
+++ b/tests/Lob/Tests/Resource/ChecksTest.php
@@ -7,7 +7,7 @@ class ChecksTest extends TestCase
 {
     protected function setUp()
     {
-        $this->lob = new Lob(LOB_TEST_API_KEY);
+        $this->lob = new Lob(getenv('LOB_API_KEY'));
         $bankAccount = $this->lob->bankAccounts()->create(
             array(
               'routing_number' => 322271627,

--- a/tests/Lob/Tests/Resource/IntlVerificationsTest.php
+++ b/tests/Lob/Tests/Resource/IntlVerificationsTest.php
@@ -7,7 +7,7 @@ class IntlVerificationsTest extends TestCase
 {
     protected function setUp()
     {
-        $this->lob = new Lob(LOB_TEST_API_KEY);
+        $this->lob = new Lob(getenv('LOB_API_KEY'));
         $this->intlAddress = array(
             'primary_line' => '123 Test St',
             'city' => 'HEARST',

--- a/tests/Lob/Tests/Resource/LettersTest.php
+++ b/tests/Lob/Tests/Resource/LettersTest.php
@@ -18,7 +18,7 @@ class LettersTest extends TestCase
             'email' => 'larry@lob.com'
         );
 
-        $this->lob = new Lob(LOB_TEST_API_KEY);
+        $this->lob = new Lob(getenv('LOB_API_KEY'));
         $this->bwLetterParams = array(
             'to' => $addressParams,
             'from' => $addressParams,

--- a/tests/Lob/Tests/Resource/PostcardsTest.php
+++ b/tests/Lob/Tests/Resource/PostcardsTest.php
@@ -7,7 +7,7 @@ class PostcardsTest extends TestCase
 {
     protected function setUp()
     {
-        $this->lob = new Lob(LOB_TEST_API_KEY);
+        $this->lob = new Lob(getenv('LOB_API_KEY'));
         $this->addressParams = array(
             'name' => 'Larry Lobster',
             'address_line1' => '185 Berry St',

--- a/tests/Lob/Tests/Resource/USAutocompletionsTest.php
+++ b/tests/Lob/Tests/Resource/USAutocompletionsTest.php
@@ -7,7 +7,7 @@ class USAutocompletionsTest extends TestCase
 {
     protected function setUp()
     {
-        $this->lob = new Lob(LOB_TEST_API_KEY);
+        $this->lob = new Lob(getenv('LOB_API_KEY'));
         $this->payload = array(
             'address_prefix' => '185 BER',
             'city' => 'SAN FRANCISCO',

--- a/tests/Lob/Tests/Resource/USVerificationsTest.php
+++ b/tests/Lob/Tests/Resource/USVerificationsTest.php
@@ -7,7 +7,7 @@ class USVerificationsTest extends TestCase
 {
     protected function setUp()
     {
-        $this->lob = new Lob(LOB_TEST_API_KEY);
+        $this->lob = new Lob(getenv('LOB_API_KEY'));
         $this->usAddress = array(
             'recipient' => 'LOB.COM',
             'primary_line' => '185 BERRY ST STE 6600',

--- a/tests/Lob/Tests/Resource/USZipLookupsTest.php
+++ b/tests/Lob/Tests/Resource/USZipLookupsTest.php
@@ -7,7 +7,7 @@ class USZipLookupsTest extends TestCase
 {
     protected function setUp()
     {
-        $this->lob = new Lob(LOB_TEST_API_KEY);
+        $this->lob = new Lob(getenv('LOB_API_KEY'));
         $this->usZip = array(
             'zip_code' => '94107'
         );


### PR DESCRIPTION
This PR removes the hardcoded API key and provides it via an environment variable in Travis (same as the other SDK clients). The previous API key has also been rotated and no longer works.