### PR TITLE
chore: bump version 3.0.6 -> 3.1.0

### DIFF
--- a/src/Lob/Lob.php
+++ b/src/Lob/Lob.php
@@ -26,7 +26,7 @@ class Lob
             $this->setApiKey($apiKey);
         }
         $this->version = $version;
-        $this->clientVersion = '3.0.6';
+        $this->clientVersion = '3.1.0';
     }
 
     public function getApiKey()


### PR DESCRIPTION
**What**
Bumps client library version identifier from 3.0.6 to 3.1.0

**Why**
Cutting new release with added self mailer support