### PR TITLE
Exclude development files from distribution

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+/examples export-ignore
+/tests export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.travis.yml export-ignore
+phpunit.xml.dist export-ignore


### PR DESCRIPTION
I've noticed that `.gitattributes` file is missing from it. It's actually a good idea to exclude unneeded dev files from the final production zip archive file, which is also downloaded by composer (unless --prefer -source is specified).

Those files are actually only useful when working on the library itself.

If you are not familiar, further information about export-ignore can be found below:
- http://www.pixelite.co.nz/article/using-git-attributes-exclude-files-your-release/
- https://madewithlove.be/gitattributes/

Hope it helps! 😊
