### PR TITLE
edit addresses+bankaccs integration tests

### DIFF
--- a/test/Integration/AddressesApiSpecTest.php
+++ b/test/Integration/AddressesApiSpecTest.php
@@ -55,6 +55,7 @@ class AddressesApiSpecTest extends TestCase
     private static $address1;
     private static $address2;
     private static $address3;
+    private static $metadata;
 
     // for teardown post-testing
     private $idsForCleanup = [];
@@ -103,6 +104,9 @@ class AddressesApiSpecTest extends TestCase
         self::$address3->setAddressCity("WESTFIELD");
         self::$address3->setAddressState("NJ");
         self::$address3->setAddressZip("07000");
+        self::$metadata = array("name"=>"Harry");
+        self::$metadata = (object)self::$metadata;
+        self::$address3->setMetadata(self::$metadata);
     }
 
     public function tearDown(): void
@@ -113,153 +117,137 @@ class AddressesApiSpecTest extends TestCase
     }
 
     public function testAddressesApiInstantiation200() {
-        try {
-            $addressApi200 = new AddressesApi(self::$config);
-            $this->assertEquals(gettype($addressApi200), 'object');
-        } catch (Exception $instantiationError) {
-            echo 'Caught exception: ',  $instantiationError->getMessage(), "\n";
-        }
+      $addressApi200 = new AddressesApi(self::$config);
+      $this->assertEquals(gettype($addressApi200), 'object');
     }
 
     public function testCreate200()
     {
-        try {
-            $createdAddress = self::$addressApi->create(self::$editableAddress);
-            $this->assertMatchesRegularExpression('/adr_/', $createdAddress->getId());
-            array_push($this->idsForCleanup, $createdAddress->getId());
-        } catch (Exception $createError) {
-            echo 'Caught exception: ',  $createError->getMessage(), "\n";
-        }
+      $createdAddress = self::$addressApi->create(self::$editableAddress);
+      $this->assertMatchesRegularExpression('/adr_/', $createdAddress->getId());
+      array_push($this->idsForCleanup, $createdAddress->getId());
     }
 
     // does not include required field in request
     public function testCreate422()
     {
-        
-        try {
-            $this->expectException(ApiException::class);
-            $this->expectExceptionMessageMatches("/address_line1 is required/");
-            $errorResponse = self::$addressApi->create(self::$errorAddress);
-        } catch (Exception $createError) {
-            echo 'Caught exception: ',  $createError->getMessage(), "\n";
-        }
+      $this->expectException(ApiException::class);
+      $this->expectExceptionMessageMatches("/address_line1 is required/");
+      $errorResponse = self::$addressApi->create(self::$errorAddress);
     }
 
     // uses a bad key to attempt to send a request
     public function testAddressApi401() {
-        try {
-            $wrongConfig = new Configuration();
-            $wrongConfig->setApiKey('basic', 'BAD KEY');
-            $addressApiError = new AddressesApi($wrongConfig);
+      $wrongConfig = new Configuration();
+      $wrongConfig->setApiKey('basic', 'BAD KEY');
+      $addressApiError = new AddressesApi($wrongConfig);
 
-            $this->expectException(ApiException::class);
-            $this->expectExceptionMessageMatches("/Your API key is not valid. Please sign up on lob.com to get a valid api key./");
-            $errorResponse = $addressApiError->create(self::$editableAddress);
-        } catch (Exception $instantiationError) {
-            echo 'Caught exception: ',  $instantiationError->getMessage(), "\n";
-        }
+      $this->expectException(ApiException::class);
+      $this->expectExceptionMessageMatches("/Your API key is not valid. Please sign up on lob.com to get a valid api key./");
+      $errorResponse = $addressApiError->create(self::$editableAddress);
     }
 
     public function testGet200()
     {
-        try {
-            $createdAddress = self::$addressApi->create(self::$editableAddress);
-            $retrievedAddress = self::$addressApi->get($createdAddress->getId());
-            $this->assertEquals($createdAddress->getAddressLine1(), $retrievedAddress->getAddressLine1());
-            array_push($this->idsForCleanup, $createdAddress->getId());
-        } catch (Exception $retrieveError) {
-            echo 'Caught exception: ',  $retrieveError->getMessage(), "\n";
-        }
+      $createdAddress = self::$addressApi->create(self::$editableAddress);
+      $retrievedAddress = self::$addressApi->get($createdAddress->getId());
+      $this->assertEquals($createdAddress->getAddressLine1(), $retrievedAddress->getAddressLine1());
+      array_push($this->idsForCleanup, $createdAddress->getId());
     }
 
     public function testGet404()
     {
-        try {
-            $this->expectException(ApiException::class);
-            $this->expectExceptionMessageMatches("/address not found/");
-            $badRetrieval = self::$addressApi->get("adr_NONEXISTENT");
-        } catch (Exception $retrieveError) {
-            echo 'Caught exception: ',  $retrieveError->getMessage(), "\n";
-        }
+      $this->expectException(ApiException::class);
+      $this->expectExceptionMessageMatches("/address not found/");
+      $badRetrieval = self::$addressApi->get("adr_NONEXISTENT");
     }
 
     public function testList200()
     {
         $nextUrl = "";
         $previousUrl = "";
-        try {
-            $add1 = self::$addressApi->create(self::$address1);
-            $add2 = self::$addressApi->create(self::$address2);
-            $add3 = self::$addressApi->create(self::$address3);
-            $listedAddresses = self::$addressApi->list(3);
-            $this->assertGreaterThan(1, count($listedAddresses->getData()));
-            $this->assertLessThanOrEqual(3, count($listedAddresses->getData()));
-            $nextUrl = substr($listedAddresses->getNextUrl(), strrpos($listedAddresses->getNextUrl(), "after=") + 6);
-            $this->assertIsString($nextUrl);
-            array_push($this->idsForCleanup, $add1->getId());
-            array_push($this->idsForCleanup, $add2->getId());
-            array_push($this->idsForCleanup, $add3->getId());
-        } catch (Exception $listError) {
-            echo 'Caught exception: ',  $listError->getMessage(), "\n";
-        }
+        $add1 = self::$addressApi->create(self::$address1);
+        $add2 = self::$addressApi->create(self::$address2);
+        $add3 = self::$addressApi->create(self::$address3);
+        $listedAddresses = self::$addressApi->list(3);
+        $this->assertGreaterThan(1, count($listedAddresses->getData()));
+        $this->assertLessThanOrEqual(3, count($listedAddresses->getData()));
+        $nextUrl = substr($listedAddresses->getNextUrl(), strrpos($listedAddresses->getNextUrl(), "after=") + 6);
+        $this->assertIsString($nextUrl);
+        array_push($this->idsForCleanup, $add1->getId());
+        array_push($this->idsForCleanup, $add2->getId());
+        array_push($this->idsForCleanup, $add3->getId());
 
         // response using nextUrl
         if ($nextUrl != "") {
-            try {
-                $add1 = self::$addressApi->create(self::$address1);
-                $add2 = self::$addressApi->create(self::$address2);
-                $add3 = self::$addressApi->create(self::$address3);
-                $listedAddressesAfter = self::$addressApi->list(3, null, $nextUrl);
-                $this->assertGreaterThan(1, count($listedAddressesAfter->getData()));
-                $this->assertLessThanOrEqual(3, count($listedAddressesAfter->getData()));
-                $previousUrl = substr($listedAddressesAfter->getPreviousUrl(), strrpos($listedAddressesAfter->getPreviousUrl(), "before=") + 7);
-                $this->assertIsString($previousUrl);
-                array_push($this->idsForCleanup, $add1->getId());
-                array_push($this->idsForCleanup, $add2->getId());
-                array_push($this->idsForCleanup, $add3->getId());
-            } catch (Exception $listError) {
-                echo 'Caught exception: ',  $listError->getMessage(), "\n";
-            }
+          $add1 = self::$addressApi->create(self::$address1);
+          $add2 = self::$addressApi->create(self::$address2);
+          $add3 = self::$addressApi->create(self::$address3);
+          $listedAddressesAfter = self::$addressApi->list(3, null, $nextUrl);
+          $this->assertGreaterThan(1, count($listedAddressesAfter->getData()));
+          $this->assertLessThanOrEqual(3, count($listedAddressesAfter->getData()));
+          $previousUrl = substr($listedAddressesAfter->getPreviousUrl(), strrpos($listedAddressesAfter->getPreviousUrl(), "before=") + 7);
+          $this->assertIsString($previousUrl);
+          array_push($this->idsForCleanup, $add1->getId());
+          array_push($this->idsForCleanup, $add2->getId());
+          array_push($this->idsForCleanup, $add3->getId());
         }
 
         // response using previousUrl
         if ($previousUrl != "") {
-            try {
-                $add1 = self::$addressApi->create(self::$address1);
-                $add2 = self::$addressApi->create(self::$address2);
-                $add3 = self::$addressApi->create(self::$address3);
-                $listedAddressesBefore = self::$addressApi->list(3, $previousUrl);
-                $this->assertGreaterThan(1, count($listedAddressesBefore->getData()));
-                $this->assertLessThanOrEqual(3, count($listedAddressesBefore->getData()));
-                array_push($this->idsForCleanup, $add1->getId());
-                array_push($this->idsForCleanup, $add2->getId());
-                array_push($this->idsForCleanup, $add3->getId());
-            } catch (Exception $listError) {
-                echo 'Caught exception: ',  $listError->getMessage(), "\n";
-            }
+          $add1 = self::$addressApi->create(self::$address1);
+          $add2 = self::$addressApi->create(self::$address2);
+          $add3 = self::$addressApi->create(self::$address3);
+          $listedAddressesBefore = self::$addressApi->list(3, $previousUrl);
+          $this->assertGreaterThan(1, count($listedAddressesBefore->getData()));
+          $this->assertLessThanOrEqual(3, count($listedAddressesBefore->getData()));
+          array_push($this->idsForCleanup, $add1->getId());
+          array_push($this->idsForCleanup, $add2->getId());
+          array_push($this->idsForCleanup, $add3->getId());
         }
+    }
+
+    public function provider()
+    {
+        return array(
+          // array(null, null, null, array("total_count"), null, null),
+        //   array(null, null, null, null, array("gt" => (string)(date("c")), "lt" => (string)(date("c", time() + 86400))), null),
+          array(null, null, null, null, null, self::$metadata),
+        );
+    }
+
+    /**
+     * @dataProvider provider
+     */
+    public function testListWithParams($limit, $before, $after, $include, $date_created, $metadata)
+    {
+        // create addresses to list
+        $add1 = self::$addressApi->create(self::$address1);
+        $add2 = self::$addressApi->create(self::$address2);
+        $add3 = self::$addressApi->create(self::$address3);
+        $listedAddresses = self::$addressApi->list($limit, $before, $after, $include, $date_created, $metadata);
+
+        $this->assertGreaterThan(0, $listedAddresses->getCount());
+        if ($include) $this->assertNotNull($listedAddresses->getTotalCount());
+
+        // delete created addresses
+        array_push($this->idsForCleanup, $add1->getId());
+        array_push($this->idsForCleanup, $add2->getId());
+        array_push($this->idsForCleanup, $add3->getId());
     }
 
     public function testDelete200()
     {
-        try {
-            $createdAddress = self::$addressApi->create(self::$editableAddress);
-            $deletedAddress = self::$addressApi->delete($createdAddress->getId());
-            $this->assertEquals(true, $deletedAddress->getDeleted());
-            $this->assertMatchesRegularExpression('/adr_/', $deletedAddress->getId());
-        } catch (Exception $deleteError) {
-            echo 'Caught exception: ',  $deleteError->getMessage(), "\n";
-        }
+      $createdAddress = self::$addressApi->create(self::$editableAddress);
+      $deletedAddress = self::$addressApi->delete($createdAddress->getId());
+      $this->assertEquals(true, $deletedAddress->getDeleted());
+      $this->assertMatchesRegularExpression('/adr_/', $deletedAddress->getId());
     }
 
     public function testDelete404()
     {
-        try {
-            $this->expectException(ApiException::class);
-            $this->expectExceptionMessageMatches("/address not found/");
-            $badDeletion = self::$addressApi->delete("adr_NONEXISTENT");
-        } catch (Exception $retrieveError) {
-            echo 'Caught exception: ',  $retrieveError->getMessage(), "\n";
-        }
+      $this->expectException(ApiException::class);
+      $this->expectExceptionMessageMatches("/address not found/");
+      $badDeletion = self::$addressApi->delete("adr_NONEXISTENT");
     }
 }

--- a/test/Integration/AddressesApiSpecTest.php
+++ b/test/Integration/AddressesApiSpecTest.php
@@ -209,9 +209,13 @@ class AddressesApiSpecTest extends TestCase
 
     public function provider()
     {
+        date_default_timezone_set('America/Los_Angeles');
+        $date_str = date("Y-m-d", strtotime("-1 months"));
+        $date_obj = (object) array("gt" => $date_str);
+
         return array(
-          // array(null, null, null, array("total_count"), null, null),
-        //   array(null, null, null, null, array("gt" => (string)(date("c")), "lt" => (string)(date("c", time() + 86400))), null),
+          array(null, null, null, array("total_count"), null, null),
+          array(null, null, null, null, $date_obj, null),
           array(null, null, null, null, null, self::$metadata),
         );
     }

--- a/test/Integration/AddressesApiSpecTest.php
+++ b/test/Integration/AddressesApiSpecTest.php
@@ -117,15 +117,23 @@ class AddressesApiSpecTest extends TestCase
     }
 
     public function testAddressesApiInstantiation200() {
-      $addressApi200 = new AddressesApi(self::$config);
-      $this->assertEquals(gettype($addressApi200), 'object');
+      try {
+        $addressApi200 = new AddressesApi(self::$config);
+        $this->assertEquals(gettype($addressApi200), 'object');
+      } catch (\Exception $e) {
+        throw new \Exception($e->getMessage());
+      }
     }
 
     public function testCreate200()
     {
-      $createdAddress = self::$addressApi->create(self::$editableAddress);
-      $this->assertMatchesRegularExpression('/adr_/', $createdAddress->getId());
-      array_push($this->idsForCleanup, $createdAddress->getId());
+      try {
+        $createdAddress = self::$addressApi->create(self::$editableAddress);
+        $this->assertMatchesRegularExpression('/adr_/', $createdAddress->getId());
+        array_push($this->idsForCleanup, $createdAddress->getId());
+      } catch (\Exception $e) {
+        throw new \Exception($e->getMessage());
+      }
     }
 
     // does not include required field in request
@@ -149,10 +157,14 @@ class AddressesApiSpecTest extends TestCase
 
     public function testGet200()
     {
-      $createdAddress = self::$addressApi->create(self::$editableAddress);
-      $retrievedAddress = self::$addressApi->get($createdAddress->getId());
-      $this->assertEquals($createdAddress->getAddressLine1(), $retrievedAddress->getAddressLine1());
-      array_push($this->idsForCleanup, $createdAddress->getId());
+      try {
+        $createdAddress = self::$addressApi->create(self::$editableAddress);
+        $retrievedAddress = self::$addressApi->get($createdAddress->getId());
+        $this->assertEquals($createdAddress->getAddressLine1(), $retrievedAddress->getAddressLine1());
+        array_push($this->idsForCleanup, $createdAddress->getId());
+      } catch (\Exception $e) {
+        throw new \Exception($e->getMessage());
+      }
     }
 
     public function testGet404()
@@ -166,44 +178,56 @@ class AddressesApiSpecTest extends TestCase
     {
         $nextUrl = "";
         $previousUrl = "";
-        $add1 = self::$addressApi->create(self::$address1);
-        $add2 = self::$addressApi->create(self::$address2);
-        $add3 = self::$addressApi->create(self::$address3);
-        $listedAddresses = self::$addressApi->list(3);
-        $this->assertGreaterThan(1, count($listedAddresses->getData()));
-        $this->assertLessThanOrEqual(3, count($listedAddresses->getData()));
-        $nextUrl = substr($listedAddresses->getNextUrl(), strrpos($listedAddresses->getNextUrl(), "after=") + 6);
-        $this->assertIsString($nextUrl);
-        array_push($this->idsForCleanup, $add1->getId());
-        array_push($this->idsForCleanup, $add2->getId());
-        array_push($this->idsForCleanup, $add3->getId());
-
-        // response using nextUrl
-        if ($nextUrl != "") {
+        try {
           $add1 = self::$addressApi->create(self::$address1);
           $add2 = self::$addressApi->create(self::$address2);
           $add3 = self::$addressApi->create(self::$address3);
-          $listedAddressesAfter = self::$addressApi->list(3, null, $nextUrl);
-          $this->assertGreaterThan(1, count($listedAddressesAfter->getData()));
-          $this->assertLessThanOrEqual(3, count($listedAddressesAfter->getData()));
-          $previousUrl = substr($listedAddressesAfter->getPreviousUrl(), strrpos($listedAddressesAfter->getPreviousUrl(), "before=") + 7);
-          $this->assertIsString($previousUrl);
+          $listedAddresses = self::$addressApi->list(3);
+          $this->assertGreaterThan(1, count($listedAddresses->getData()));
+          $this->assertLessThanOrEqual(3, count($listedAddresses->getData()));
+          $nextUrl = substr($listedAddresses->getNextUrl(), strrpos($listedAddresses->getNextUrl(), "after=") + 6);
+          $this->assertIsString($nextUrl);
           array_push($this->idsForCleanup, $add1->getId());
           array_push($this->idsForCleanup, $add2->getId());
           array_push($this->idsForCleanup, $add3->getId());
+        } catch (\Exception $e) {
+          throw new \Exception($e->getMessage());
+        }
+
+        // response using nextUrl
+        if ($nextUrl != "") {
+          try {
+            $add1 = self::$addressApi->create(self::$address1);
+            $add2 = self::$addressApi->create(self::$address2);
+            $add3 = self::$addressApi->create(self::$address3);
+            $listedAddressesAfter = self::$addressApi->list(3, null, $nextUrl);
+            $this->assertGreaterThan(1, count($listedAddressesAfter->getData()));
+            $this->assertLessThanOrEqual(3, count($listedAddressesAfter->getData()));
+            $previousUrl = substr($listedAddressesAfter->getPreviousUrl(), strrpos($listedAddressesAfter->getPreviousUrl(), "before=") + 7);
+            $this->assertIsString($previousUrl);
+            array_push($this->idsForCleanup, $add1->getId());
+            array_push($this->idsForCleanup, $add2->getId());
+            array_push($this->idsForCleanup, $add3->getId());
+          } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+          }
         }
 
         // response using previousUrl
         if ($previousUrl != "") {
-          $add1 = self::$addressApi->create(self::$address1);
-          $add2 = self::$addressApi->create(self::$address2);
-          $add3 = self::$addressApi->create(self::$address3);
-          $listedAddressesBefore = self::$addressApi->list(3, $previousUrl);
-          $this->assertGreaterThan(1, count($listedAddressesBefore->getData()));
-          $this->assertLessThanOrEqual(3, count($listedAddressesBefore->getData()));
-          array_push($this->idsForCleanup, $add1->getId());
-          array_push($this->idsForCleanup, $add2->getId());
-          array_push($this->idsForCleanup, $add3->getId());
+          try {
+            $add1 = self::$addressApi->create(self::$address1);
+            $add2 = self::$addressApi->create(self::$address2);
+            $add3 = self::$addressApi->create(self::$address3);
+            $listedAddressesBefore = self::$addressApi->list(3, $previousUrl);
+            $this->assertGreaterThan(1, count($listedAddressesBefore->getData()));
+            $this->assertLessThanOrEqual(3, count($listedAddressesBefore->getData()));
+            array_push($this->idsForCleanup, $add1->getId());
+            array_push($this->idsForCleanup, $add2->getId());
+            array_push($this->idsForCleanup, $add3->getId());
+          } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+          }
         }
     }
 
@@ -225,6 +249,7 @@ class AddressesApiSpecTest extends TestCase
      */
     public function testListWithParams($limit, $before, $after, $include, $date_created, $metadata)
     {
+      try {
         // create addresses to list
         $add1 = self::$addressApi->create(self::$address1);
         $add2 = self::$addressApi->create(self::$address2);
@@ -238,14 +263,21 @@ class AddressesApiSpecTest extends TestCase
         array_push($this->idsForCleanup, $add1->getId());
         array_push($this->idsForCleanup, $add2->getId());
         array_push($this->idsForCleanup, $add3->getId());
+      } catch (\Exception $e) {
+        throw new \Exception($e->getMessage());
+      }
     }
 
     public function testDelete200()
     {
-      $createdAddress = self::$addressApi->create(self::$editableAddress);
-      $deletedAddress = self::$addressApi->delete($createdAddress->getId());
-      $this->assertEquals(true, $deletedAddress->getDeleted());
-      $this->assertMatchesRegularExpression('/adr_/', $deletedAddress->getId());
+      try {
+        $createdAddress = self::$addressApi->create(self::$editableAddress);
+        $deletedAddress = self::$addressApi->delete($createdAddress->getId());
+        $this->assertEquals(true, $deletedAddress->getDeleted());
+        $this->assertMatchesRegularExpression('/adr_/', $deletedAddress->getId());
+      } catch (\Exception $e) {
+        throw new \Exception($e->getMessage());
+      }
     }
 
     public function testDelete404()

--- a/test/Integration/BankAccountsApiSpecTest.php
+++ b/test/Integration/BankAccountsApiSpecTest.php
@@ -248,9 +248,13 @@ class BankAccountsApiSpecTest extends TestCase
 
     public function provider()
     {
+        date_default_timezone_set('America/Los_Angeles');
+        $date_str = date("Y-m-d", strtotime("-1 months"));
+        $date_obj = (object) array("gt" => $date_str);
+
         return array(
-        //   array(null, null, null, array("total_count"), null, null),
-        //   array(null, null, null, null, array("gt" => (string)(date("c")), "lt" => (string)(date("c", time() + 86400))), null),
+          array(null, null, null, array("total_count"), null, null),
+          array(null, null, null, null, $date_obj, null),
           array(null, null, null, null, null, self::$metadata),
         );
     }

--- a/test/Integration/BankAccountsApiSpecTest.php
+++ b/test/Integration/BankAccountsApiSpecTest.php
@@ -52,11 +52,14 @@ class BankAccountsApiSpecTest extends TestCase
      */
     private static $config;
     private static $bankApi;
+    private static $invalidBankApi;
     private static $writableBankAcc;
     private static $errorBank;
     private static $ba1;
     private static $ba2;
     private static $ba3;
+    private static $bankVerify;
+    private static $metadata;
 
     // for teardown post-testing
     private $idsForCleanup = [];
@@ -66,8 +69,12 @@ class BankAccountsApiSpecTest extends TestCase
     {
         // create instance of BankAccountsApi & editable bank accounts for other tests
         self::$config = new Configuration();
-        self::$config->setApiKey('basic', getenv('LOB_API_TEST_KEY'));
+        self::$config->setApiKey("basic", getenv("LOB_API_TEST_KEY"));
         self::$bankApi = new BankAccountsApi(self::$config);
+
+        $invalid_config = new Configuration();
+        $invalid_config->setApiKey("basic", "Totally Fake Key");
+        self::$invalidBankApi = new BankAccountsApi($invalid_config);
 
         self::$writableBankAcc = new BankAccountWritable();
         self::$writableBankAcc->setDescription("PHP test bank account");
@@ -81,6 +88,9 @@ class BankAccountsApiSpecTest extends TestCase
         self::$errorBank->setAccountNumber("123456789");
         self::$errorBank->setSignatory("Sinead Connor");
         self::$errorBank->setAccountType(BankTypeEnum::INDIVIDUAL->value);
+
+        self::$bankVerify = new BankAccountVerify();
+        self::$bankVerify->setAmounts([11, 35]);
 
         // for testing list function
         self::$ba1 = new BankAccountWritable();
@@ -103,6 +113,8 @@ class BankAccountsApiSpecTest extends TestCase
         self::$ba3->setAccountNumber("123456789");
         self::$ba3->setSignatory("Niamh Connor");
         self::$ba3->setAccountType(BankTypeEnum::INDIVIDUAL->value);
+        self::$metadata = (object)array("name"=>"Harry");
+        self::$ba3->setMetadata(self::$metadata);
     }
 
     public function tearDown(): void
@@ -113,167 +125,179 @@ class BankAccountsApiSpecTest extends TestCase
     }
 
     public function testBankAccountsApiInstantiation200() {
-        try {
-            $baApi200 = new BankAccountsApi(self::$config);
-            $this->assertEquals(gettype($baApi200), 'object');
-        } catch (Exception $instantiationError) {
-            echo 'Caught exception: ',  $instantiationError->getMessage(), "\n";
-        }
+        $baApi200 = new BankAccountsApi(self::$config);
+        $this->assertEquals(gettype($baApi200), "object");
     }
 
     public function testCreate200()
     {
-        try {
-            $createdBankAccount = self::$bankApi->create(self::$writableBankAcc);
-            $this->assertMatchesRegularExpression('/bank_/', $createdBankAccount->getId());
-            array_push($this->idsForCleanup, $createdBankAccount->getId());
-        } catch (Exception $createError) {
-            echo 'Caught exception: ',  $createError->getMessage(), "\n,";
-        }
+        $createdBankAccount = self::$bankApi->create(self::$writableBankAcc);
+        $this->assertMatchesRegularExpression("/bank_/", $createdBankAccount->getId());
+        array_push($this->idsForCleanup, $createdBankAccount->getId());
     }
 
     // does not include required field in request
     public function testCreate422()
     {
-        try {
-            $this->expectException(ApiException::class);
-            $this->expectExceptionMessageMatches("/routing_number is required/");
-            $errorResponse = self::$bankApi->create(self::$errorBank);
-        } catch (Exception $createError) {
-            echo 'Caught exception: ',  $createError->getMessage(), "\n";
-        }
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessageMatches("/routing_number is required/");
+        $errorResponse = self::$bankApi->create(self::$errorBank);
     }
 
     // uses a bad key to attempt to send a request
     public function testBankAccountApi401() {
-        try {
-            $wrongConfig = new Configuration();
-            $wrongConfig->setApiKey('basic', 'BAD KEY');
-            $bankApiError = new BankAccountsApi($wrongConfig);
-
-            $this->expectException(ApiException::class);
-            $this->expectExceptionMessageMatches("/Your API key is not valid. Please sign up on lob.com to get a valid api key./");
-            $errorResponse = $bankApiError->create(self::$writableBankAcc);
-        } catch (Exception $instantiationError) {
-            echo 'Caught exception: ',  $instantiationError->getMessage(), "\n";
-        }
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessageMatches("/Your API key is not valid. Please sign up on lob.com to get a valid api key./");
+        $errorResponse = self::$invalidBankApi->create(self::$writableBankAcc);
     }
 
-    public function testVerify422()
+    public function testVerify200()
     {
-        try {
-            $bankVerify = new BankAccountVerify();
-            $bankVerify->setAmounts([11, 35]);
+        $createdBankAccount = self::$bankApi->create(self::$writableBankAcc);
+        $verifiedBankAccount = self::$bankApi->verify($createdBankAccount->getId(), self::$bankVerify);
+        $this->assertMatchesRegularExpression("/bank_/", $createdBankAccount->getId());
+        array_push($this->idsForCleanup, $createdBankAccount->getId());
+    }
 
-            $createdBankAccount = self::$bankApi->create(self::$writableBankAcc);
-            $verifiedBankAccount = self::$bankApi->verify($createdBankAccount->getId(), $bankVerify);
-            $this->assertMatchesRegularExpression('/bank_/', $createdBankAccount->getId());
-            array_push($this->idsForCleanup, $createdBankAccount->getId());
-        } catch (Exception $createError) {
-            echo 'Caught exception: ',  $createError->getMessage(), "\n,";
-        }
+    public function testVerify401()
+    {
+        $createdBankAccount = self::$bankApi->create(self::$writableBankAcc);
+        array_push($this->idsForCleanup, $createdBankAccount->getId());
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessageMatches("/Your API key is not valid/");
+        $verifiedBankAccount = self::$invalidBankApi->verify($createdBankAccount->getId(), self::$bankVerify);
+    }
+
+    public function testVerify404()
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessageMatches("/not found/");
+        $verifiedBankAccount = self::$bankApi->verify("bank_fakeId", self::$bankVerify);
     }
 
     public function testGet200()
     {
-        try {
-            $createdAcc = self::$bankApi->create(self::$writableBankAcc);
-            $retrievedAcc = self::$bankApi->get($createdAcc->getId());
-            $this->assertEquals($createdAcc->getRoutingNumber(), $retrievedAcc->getRoutingNumber());
-            array_push($this->idsForCleanup, $createdAcc->getId());
-        } catch (Exception $retrieveError) {
-            echo 'Caught exception: ',  $retrieveError->getMessage(), "\n";
-        }
+        $createdAcc = self::$bankApi->create(self::$writableBankAcc);
+        $retrievedAcc = self::$bankApi->get($createdAcc->getId());
+        $this->assertEquals($createdAcc->getRoutingNumber(), $retrievedAcc->getRoutingNumber());
+        array_push($this->idsForCleanup, $createdAcc->getId());
+    }
+
+    public function testGet401()
+    {
+        $createdBankAccount = self::$bankApi->create(self::$writableBankAcc);
+        array_push($this->idsForCleanup, $createdBankAccount->getId());
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessageMatches("/Your API key is not valid/");
+        $badRetrieval = self::$invalidBankApi->get($createdBankAccount->getId());
     }
 
     public function testGet404()
     {
-        try {
-            $this->expectException(ApiException::class);
-            $this->expectExceptionMessageMatches("/bank account not found/");
-            $badRetrieval = self::$bankApi->get("bank_NONEXISTENT");
-        } catch (Exception $retrieveError) {
-            echo 'Caught exception: ',  $retrieveError->getMessage(), "\n";
-        }
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessageMatches("/bank account not found/");
+        $badRetrieval = self::$bankApi->get("bank_NONEXISTENT");
     }
 
     public function testList200()
     {
         $nextUrl = "";
         $previousUrl = "";
-        try {
-            $bank1 = self::$bankApi->create(self::$ba1);
-            $bank2 = self::$bankApi->create(self::$ba2);
-            $bank3 = self::$bankApi->create(self::$ba3);
-            $listedBankAccounts = self::$bankApi->list(3);
-            $this->assertGreaterThan(1, count($listedBankAccounts->getData()));
-            $this->assertLessThanOrEqual(3, count($listedBankAccounts->getData()));
-            $nextUrl = substr($listedBankAccounts->getNextUrl(), strrpos($listedBankAccounts->getNextUrl(), "after=") + 6);
-            $this->assertIsString($nextUrl);
-            array_push($this->idsForCleanup, $bank1->getId());
-            array_push($this->idsForCleanup, $bank2->getId());
-            array_push($this->idsForCleanup, $bank3->getId());
-        } catch (Exception $listError) {
-            echo 'Caught exception: ',  $listError->getMessage(), "\n";
-        }
+        $bank1 = self::$bankApi->create(self::$ba1);
+        $bank2 = self::$bankApi->create(self::$ba2);
+        $bank3 = self::$bankApi->create(self::$ba3);
+        $listedBankAccounts = self::$bankApi->list(3);
+        $this->assertGreaterThan(1, count($listedBankAccounts->getData()));
+        $this->assertLessThanOrEqual(3, count($listedBankAccounts->getData()));
+        $nextUrl = substr($listedBankAccounts->getNextUrl(), strrpos($listedBankAccounts->getNextUrl(), "after=") + 6);
+        $this->assertIsString($nextUrl);
+        array_push($this->idsForCleanup, $bank1->getId());
+        array_push($this->idsForCleanup, $bank2->getId());
+        array_push($this->idsForCleanup, $bank3->getId());
 
         // response using nextUrl
         if ($nextUrl != "") {
-            try {
-                $bank1 = self::$bankApi->create(self::$ba1);
-                $bank2 = self::$bankApi->create(self::$ba2);
-                $bank3 = self::$bankApi->create(self::$ba3);
-                $listedBankAccountsAfter = self::$bankApi->list(3, null, $nextUrl);
-                $this->assertGreaterThan(1, count($listedBankAccountsAfter->getData()));
-                $this->assertLessThanOrEqual(3, count($listedBankAccountsAfter->getData()));
-                $previousUrl = substr($listedBankAccountsAfter->getPreviousUrl(), strrpos($listedBankAccountsAfter->getPreviousUrl(), "before=") + 7);
-                $this->assertIsString($previousUrl);
-                array_push($this->idsForCleanup, $bank1->getId());
-                array_push($this->idsForCleanup, $bank2->getId());
-                array_push($this->idsForCleanup, $bank3->getId());
-            } catch (Exception $listError) {
-                echo 'Caught exception: ',  $listError->getMessage(), "\n";
-            }
+            $bank1 = self::$bankApi->create(self::$ba1);
+            $bank2 = self::$bankApi->create(self::$ba2);
+            $bank3 = self::$bankApi->create(self::$ba3);
+            $listedBankAccountsAfter = self::$bankApi->list(3, null, $nextUrl);
+            $this->assertGreaterThan(1, count($listedBankAccountsAfter->getData()));
+            $this->assertLessThanOrEqual(3, count($listedBankAccountsAfter->getData()));
+            $previousUrl = substr($listedBankAccountsAfter->getPreviousUrl(), strrpos($listedBankAccountsAfter->getPreviousUrl(), "before=") + 7);
+            $this->assertIsString($previousUrl);
+            array_push($this->idsForCleanup, $bank1->getId());
+            array_push($this->idsForCleanup, $bank2->getId());
+            array_push($this->idsForCleanup, $bank3->getId());
         }
 
         // response using previousUrl
         if ($previousUrl != "") {
-            try {
-                $bank1 = self::$bankApi->create(self::$ba1);
-                $bank2 = self::$bankApi->create(self::$ba2);
-                $bank3 = self::$bankApi->create(self::$ba3);
-                $listedBankAccountsBefore = self::$bankApi->list(3, $previousUrl);
-                $this->assertGreaterThan(1, count($listedBankAccountsBefore->getData()));
-                $this->assertLessThanOrEqual(3, count($listedBankAccountsBefore->getData()));
-                array_push($this->idsForCleanup, $bank1->getId());
-                array_push($this->idsForCleanup, $bank2->getId());
-                array_push($this->idsForCleanup, $bank3->getId());
-            } catch (Exception $listError) {
-                echo 'Caught exception: ',  $listError->getMessage(), "\n";
-            }
+            $bank1 = self::$bankApi->create(self::$ba1);
+            $bank2 = self::$bankApi->create(self::$ba2);
+            $bank3 = self::$bankApi->create(self::$ba3);
+            $listedBankAccountsBefore = self::$bankApi->list(3, $previousUrl);
+            $this->assertGreaterThan(1, count($listedBankAccountsBefore->getData()));
+            $this->assertLessThanOrEqual(3, count($listedBankAccountsBefore->getData()));
+            array_push($this->idsForCleanup, $bank1->getId());
+            array_push($this->idsForCleanup, $bank2->getId());
+            array_push($this->idsForCleanup, $bank3->getId());
         }
+    }
+
+    public function provider()
+    {
+        return array(
+        //   array(null, null, null, array("total_count"), null, null),
+        //   array(null, null, null, null, array("gt" => (string)(date("c")), "lt" => (string)(date("c", time() + 86400))), null),
+          array(null, null, null, null, null, self::$metadata),
+        );
+    }
+
+    /**
+     * @dataProvider provider
+     */
+    public function testListWithParams($limit, $before, $after, $include, $date_created, $metadata)
+    {
+        // create bank accounts to list
+        $bank1 = self::$bankApi->create(self::$ba1);
+        $bank2 = self::$bankApi->create(self::$ba2);
+        $bank3 = self::$bankApi->create(self::$ba3);
+        $listedBankAccounts = self::$bankApi->list($limit, $before, $after, $include, $date_created, $metadata);
+
+        $this->assertGreaterThan(0, $listedBankAccounts->getCount());
+        if ($include) $this->assertNotNull($listedBankAccounts->getTotalCount());
+
+        // delete created bank accounts
+        array_push($this->idsForCleanup, $bank1->getId());
+        array_push($this->idsForCleanup, $bank2->getId());
+        array_push($this->idsForCleanup, $bank3->getId());
     }
 
     public function testDelete200()
     {
-        try {
-            $createdAcc = self::$bankApi->create(self::$writableBankAcc);
-            $deletedAcc = self::$bankApi->delete($createdAcc->getId());
-            $this->assertEquals(true, $deletedAcc->getDeleted());
-            $this->assertMatchesRegularExpression('/bank_/', $deletedAcc->getId());
-        } catch (Exception $deleteError) {
-            echo 'Caught exception: ',  $deleteError->getMessage(), "\n";
-        }
+        $createdAcc = self::$bankApi->create(self::$writableBankAcc);
+        $deletedAcc = self::$bankApi->delete($createdAcc->getId());
+        $this->assertEquals(true, $deletedAcc->getDeleted());
+        $this->assertMatchesRegularExpression("/bank_/", $deletedAcc->getId());
     }
+
+    public function testDelete401()
+    {
+        $createdBankAccount = self::$bankApi->create(self::$writableBankAcc);
+        array_push($this->idsForCleanup, $createdBankAccount->getId());
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessageMatches("/Your API key is not valid/");
+        $badRetrieval = self::$invalidBankApi->delete($createdBankAccount->getId());
+    }
+
 
     public function testDelete404()
     {
-        try {
-            $this->expectException(ApiException::class);
-            $this->expectExceptionMessageMatches("/bank account not found/");
-            $badDeletion = self::$bankApi->delete("bank_NONEXISTENT");
-        } catch (Exception $retrieveError) {
-            echo 'Caught exception: ',  $retrieveError->getMessage(), "\n";
-        }
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessageMatches("/bank account not found/");
+        $badDeletion = self::$bankApi->delete("bank_NONEXISTENT");
     }
 }

--- a/test/Integration/BankAccountsApiSpecTest.php
+++ b/test/Integration/BankAccountsApiSpecTest.php
@@ -125,15 +125,23 @@ class BankAccountsApiSpecTest extends TestCase
     }
 
     public function testBankAccountsApiInstantiation200() {
-        $baApi200 = new BankAccountsApi(self::$config);
-        $this->assertEquals(gettype($baApi200), "object");
+        try {
+            $baApi200 = new BankAccountsApi(self::$config);
+            $this->assertEquals(gettype($baApi200), "object");
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+        }
     }
 
     public function testCreate200()
     {
-        $createdBankAccount = self::$bankApi->create(self::$writableBankAcc);
-        $this->assertMatchesRegularExpression("/bank_/", $createdBankAccount->getId());
-        array_push($this->idsForCleanup, $createdBankAccount->getId());
+        try {
+            $createdBankAccount = self::$bankApi->create(self::$writableBankAcc);
+            $this->assertMatchesRegularExpression("/bank_/", $createdBankAccount->getId());
+            array_push($this->idsForCleanup, $createdBankAccount->getId());
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+        }
     }
 
     // does not include required field in request
@@ -153,10 +161,14 @@ class BankAccountsApiSpecTest extends TestCase
 
     public function testVerify200()
     {
-        $createdBankAccount = self::$bankApi->create(self::$writableBankAcc);
-        $verifiedBankAccount = self::$bankApi->verify($createdBankAccount->getId(), self::$bankVerify);
-        $this->assertMatchesRegularExpression("/bank_/", $createdBankAccount->getId());
-        array_push($this->idsForCleanup, $createdBankAccount->getId());
+        try {
+            $createdBankAccount = self::$bankApi->create(self::$writableBankAcc);
+            $verifiedBankAccount = self::$bankApi->verify($createdBankAccount->getId(), self::$bankVerify);
+            $this->assertMatchesRegularExpression("/bank_/", $createdBankAccount->getId());
+            array_push($this->idsForCleanup, $createdBankAccount->getId());
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+        }
     }
 
     public function testVerify401()
@@ -178,10 +190,14 @@ class BankAccountsApiSpecTest extends TestCase
 
     public function testGet200()
     {
-        $createdAcc = self::$bankApi->create(self::$writableBankAcc);
-        $retrievedAcc = self::$bankApi->get($createdAcc->getId());
-        $this->assertEquals($createdAcc->getRoutingNumber(), $retrievedAcc->getRoutingNumber());
-        array_push($this->idsForCleanup, $createdAcc->getId());
+        try {
+            $createdAcc = self::$bankApi->create(self::$writableBankAcc);
+            $retrievedAcc = self::$bankApi->get($createdAcc->getId());
+            $this->assertEquals($createdAcc->getRoutingNumber(), $retrievedAcc->getRoutingNumber());
+            array_push($this->idsForCleanup, $createdAcc->getId());
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+        }
     }
 
     public function testGet401()
@@ -205,44 +221,56 @@ class BankAccountsApiSpecTest extends TestCase
     {
         $nextUrl = "";
         $previousUrl = "";
-        $bank1 = self::$bankApi->create(self::$ba1);
-        $bank2 = self::$bankApi->create(self::$ba2);
-        $bank3 = self::$bankApi->create(self::$ba3);
-        $listedBankAccounts = self::$bankApi->list(3);
-        $this->assertGreaterThan(1, count($listedBankAccounts->getData()));
-        $this->assertLessThanOrEqual(3, count($listedBankAccounts->getData()));
-        $nextUrl = substr($listedBankAccounts->getNextUrl(), strrpos($listedBankAccounts->getNextUrl(), "after=") + 6);
-        $this->assertIsString($nextUrl);
-        array_push($this->idsForCleanup, $bank1->getId());
-        array_push($this->idsForCleanup, $bank2->getId());
-        array_push($this->idsForCleanup, $bank3->getId());
-
-        // response using nextUrl
-        if ($nextUrl != "") {
+        try {
             $bank1 = self::$bankApi->create(self::$ba1);
             $bank2 = self::$bankApi->create(self::$ba2);
             $bank3 = self::$bankApi->create(self::$ba3);
-            $listedBankAccountsAfter = self::$bankApi->list(3, null, $nextUrl);
-            $this->assertGreaterThan(1, count($listedBankAccountsAfter->getData()));
-            $this->assertLessThanOrEqual(3, count($listedBankAccountsAfter->getData()));
-            $previousUrl = substr($listedBankAccountsAfter->getPreviousUrl(), strrpos($listedBankAccountsAfter->getPreviousUrl(), "before=") + 7);
-            $this->assertIsString($previousUrl);
+            $listedBankAccounts = self::$bankApi->list(3);
+            $this->assertGreaterThan(1, count($listedBankAccounts->getData()));
+            $this->assertLessThanOrEqual(3, count($listedBankAccounts->getData()));
+            $nextUrl = substr($listedBankAccounts->getNextUrl(), strrpos($listedBankAccounts->getNextUrl(), "after=") + 6);
+            $this->assertIsString($nextUrl);
             array_push($this->idsForCleanup, $bank1->getId());
             array_push($this->idsForCleanup, $bank2->getId());
             array_push($this->idsForCleanup, $bank3->getId());
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+        }
+
+        // response using nextUrl
+        if ($nextUrl != "") {
+            try {
+                $bank1 = self::$bankApi->create(self::$ba1);
+                $bank2 = self::$bankApi->create(self::$ba2);
+                $bank3 = self::$bankApi->create(self::$ba3);
+                $listedBankAccountsAfter = self::$bankApi->list(3, null, $nextUrl);
+                $this->assertGreaterThan(1, count($listedBankAccountsAfter->getData()));
+                $this->assertLessThanOrEqual(3, count($listedBankAccountsAfter->getData()));
+                $previousUrl = substr($listedBankAccountsAfter->getPreviousUrl(), strrpos($listedBankAccountsAfter->getPreviousUrl(), "before=") + 7);
+                $this->assertIsString($previousUrl);
+                array_push($this->idsForCleanup, $bank1->getId());
+                array_push($this->idsForCleanup, $bank2->getId());
+                array_push($this->idsForCleanup, $bank3->getId());
+            } catch (\Exception $e) {
+                throw new \Exception($e->getMessage());
+            }
         }
 
         // response using previousUrl
         if ($previousUrl != "") {
-            $bank1 = self::$bankApi->create(self::$ba1);
-            $bank2 = self::$bankApi->create(self::$ba2);
-            $bank3 = self::$bankApi->create(self::$ba3);
-            $listedBankAccountsBefore = self::$bankApi->list(3, $previousUrl);
-            $this->assertGreaterThan(1, count($listedBankAccountsBefore->getData()));
-            $this->assertLessThanOrEqual(3, count($listedBankAccountsBefore->getData()));
-            array_push($this->idsForCleanup, $bank1->getId());
-            array_push($this->idsForCleanup, $bank2->getId());
-            array_push($this->idsForCleanup, $bank3->getId());
+            try {
+                $bank1 = self::$bankApi->create(self::$ba1);
+                $bank2 = self::$bankApi->create(self::$ba2);
+                $bank3 = self::$bankApi->create(self::$ba3);
+                $listedBankAccountsBefore = self::$bankApi->list(3, $previousUrl);
+                $this->assertGreaterThan(1, count($listedBankAccountsBefore->getData()));
+                $this->assertLessThanOrEqual(3, count($listedBankAccountsBefore->getData()));
+                array_push($this->idsForCleanup, $bank1->getId());
+                array_push($this->idsForCleanup, $bank2->getId());
+                array_push($this->idsForCleanup, $bank3->getId());
+            } catch (\Exception $e) {
+                throw new \Exception($e->getMessage());
+            }
         }
     }
 
@@ -264,27 +292,35 @@ class BankAccountsApiSpecTest extends TestCase
      */
     public function testListWithParams($limit, $before, $after, $include, $date_created, $metadata)
     {
-        // create bank accounts to list
-        $bank1 = self::$bankApi->create(self::$ba1);
-        $bank2 = self::$bankApi->create(self::$ba2);
-        $bank3 = self::$bankApi->create(self::$ba3);
-        $listedBankAccounts = self::$bankApi->list($limit, $before, $after, $include, $date_created, $metadata);
+        try {
+            // create bank accounts to list
+            $bank1 = self::$bankApi->create(self::$ba1);
+            $bank2 = self::$bankApi->create(self::$ba2);
+            $bank3 = self::$bankApi->create(self::$ba3);
+            $listedBankAccounts = self::$bankApi->list($limit, $before, $after, $include, $date_created, $metadata);
 
-        $this->assertGreaterThan(0, $listedBankAccounts->getCount());
-        if ($include) $this->assertNotNull($listedBankAccounts->getTotalCount());
+            $this->assertGreaterThan(0, $listedBankAccounts->getCount());
+            if ($include) $this->assertNotNull($listedBankAccounts->getTotalCount());
 
-        // delete created bank accounts
-        array_push($this->idsForCleanup, $bank1->getId());
-        array_push($this->idsForCleanup, $bank2->getId());
-        array_push($this->idsForCleanup, $bank3->getId());
+            // delete created bank accounts
+            array_push($this->idsForCleanup, $bank1->getId());
+            array_push($this->idsForCleanup, $bank2->getId());
+            array_push($this->idsForCleanup, $bank3->getId());
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+        }
     }
 
     public function testDelete200()
     {
-        $createdAcc = self::$bankApi->create(self::$writableBankAcc);
-        $deletedAcc = self::$bankApi->delete($createdAcc->getId());
-        $this->assertEquals(true, $deletedAcc->getDeleted());
-        $this->assertMatchesRegularExpression("/bank_/", $deletedAcc->getId());
+        try {
+            $createdAcc = self::$bankApi->create(self::$writableBankAcc);
+            $deletedAcc = self::$bankApi->delete($createdAcc->getId());
+            $this->assertEquals(true, $deletedAcc->getDeleted());
+            $this->assertMatchesRegularExpression("/bank_/", $deletedAcc->getId());
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+        }
     }
 
     public function testDelete401()

--- a/test/Integration/BillingGroupsApiSpecTest.php
+++ b/test/Integration/BillingGroupsApiSpecTest.php
@@ -33,6 +33,7 @@ use \OpenAPI\Client\ApiException;
 use PHPUnit\Framework\TestCase;
 use \OpenAPI\Client\Model\BillingGroupEditable;
 use \OpenAPI\Client\Api\BillingGroupsApi;
+use \OpenAPI\Client\Model\SortBy5;
 
 /**
  * BillingGroupsApiSpecTest Class Doc Comment
@@ -50,6 +51,7 @@ class BillingGroupsApiSpecTest extends TestCase
      */
     private static $config;
     private static $billingApi;
+    private static $invalidBillingApi;
     private static $editableBillingGroup;
     private static $errorBillingGroup;
     private static $bg1;
@@ -61,8 +63,12 @@ class BillingGroupsApiSpecTest extends TestCase
     {
         // create instance of BillingGroupsApi
         self::$config = new Configuration();
-        self::$config->setApiKey('basic', getenv('LOB_API_TEST_KEY'));
+        self::$config->setApiKey("basic", getenv("LOB_API_TEST_KEY"));
         self::$billingApi = new BillingGroupsApi(self::$config);
+
+        $invalidConfig = new Configuration();
+        $invalidConfig->setApiKey("basic", "Totally Fake Key");
+        self::$invalidBillingApi = new BillingGroupsApi($invalidConfig);
 
         self::$editableBillingGroup = new BillingGroupEditable();
         self::$editableBillingGroup->setDescription("Dummy Billing Group (Integration Test)");
@@ -86,85 +92,69 @@ class BillingGroupsApiSpecTest extends TestCase
     }
 
     public function testBillingGroupsApiInstantiation200() {
-        try {
-            $bgApi200 = new BillingGroupsApi(self::$config);
-            $this->assertEquals(gettype($bgApi200), 'object');
-        } catch (Exception $instantiationError) {
-            echo 'Caught exception: ',  $instantiationError->getMessage(), "\n";
-        }
+        $bgApi200 = new BillingGroupsApi(self::$config);
+        $this->assertEquals(gettype($bgApi200), "object");
     }
 
     public function testCreate200()
     {
-        try {
-            $createdBillingGroup = self::$billingApi->create(self::$editableBillingGroup);
-            $this->assertMatchesRegularExpression('/bg_/', $createdBillingGroup->getId());
-        } catch (Exception $createError) {
-            echo 'Caught exception: ',  $createError->getMessage(), "\n";
-        }
+        $createdBillingGroup = self::$billingApi->create(self::$editableBillingGroup);
+        $this->assertMatchesRegularExpression("/bg_/", $createdBillingGroup->getId());
     }
 
     // does not include required field in request
     public function testCreate422()
     {
-        
-        try {
-            $this->expectException(ApiException::class);
-            $this->expectExceptionMessageMatches("/name is required/");
-            $errorResponse = self::$billingApi->create(self::$errorBillingGroup);
-        } catch (Exception $createError) {
-            echo 'Caught exception: ',  $createError->getMessage(), "\n";
-        }
+        $this->expectException(ApiException::class);
+        $this->expectExceptionMessageMatches("/name is required/");
+        $errorResponse = self::$billingApi->create(self::$errorBillingGroup);
     }
 
     // uses a bad key to attempt to send a request
     public function testBillingGroupApi401() {
-        try {
-            $wrongConfig = new Configuration();
-            $wrongConfig->setApiKey('basic', 'BAD KEY');
-            $bgApiError = new BillingGroupsApi($wrongConfig);
-
-            $this->expectException(ApiException::class);
-            $this->expectExceptionMessageMatches("/Your API key is not valid. Please sign up on lob.com to get a valid api key./");
-            $errorResponse = $bgApiError->create(self::$editableBillingGroup);
-        } catch (Exception $instantiationError) {
-            echo 'Caught exception: ',  $instantiationError->getMessage(), "\n";
-        }
+        $this->expectException(ApiException::class);
+        $this->expectExceptionMessageMatches("/Your API key is not valid. Please sign up on lob.com to get a valid api key./");
+        $errorResponse = self::$invalidBillingApi->create(self::$editableBillingGroup);
     }
 
     public function testGet200()
     {
-        try {
-            $createdBillingGroup = self::$billingApi->create(self::$editableBillingGroup);
-            $retrievedBillingGroup = self::$billingApi->get($createdBillingGroup->getId());
-            $this->assertEquals($createdBillingGroup->getDescription(), $retrievedBillingGroup->getDescription());
-        } catch (Exception $retrieveError) {
-            echo 'Caught exception: ',  $retrieveError->getMessage(), "\n";
-        }
+        $createdBillingGroup = self::$billingApi->create(self::$editableBillingGroup);
+        $retrievedBillingGroup = self::$billingApi->get($createdBillingGroup->getId());
+        $this->assertEquals($createdBillingGroup->getDescription(), $retrievedBillingGroup->getDescription());
     }
 
     public function testGet404()
     {
-        try {
-            $this->expectException(ApiException::class);
-            $this->expectExceptionMessageMatches("/billing_group not found/");
-            $badRetrieval = self::$billingApi->get("bg_NONEXISTENT");
-        } catch (Exception $retrieveError) {
-            echo 'Caught exception: ',  $retrieveError->getMessage(), "\n";
-        }
+        $this->expectException(ApiException::class);
+        $this->expectExceptionMessageMatches("/billing_group not found/");
+        $badRetrieval = self::$billingApi->get("bg_NONEXISTENT");
     }
 
     public function testUpdate200()
     {
-        try {
-            $bgUpdatable = new BillingGroupEditable();
-            $bgUpdatable->setDescription("Updated Billing Group");
-            $createdBillingGroup = self::$billingApi->create(self::$editableBillingGroup);
-            $retrievedBillingGroup = self::$billingApi->update($createdBillingGroup->getId(), $bgUpdatable);
-            $this->assertEquals("Updated Billing Group", $retrievedBillingGroup->getDescription());
-        } catch (Exception $retrieveError) {
-            echo 'Caught exception: ',  $retrieveError->getMessage(), "\n";
-        }
+        $bgUpdatable = new BillingGroupEditable();
+        $bgUpdatable->setDescription("Updated Billing Group");
+        $createdBillingGroup = self::$billingApi->create(self::$editableBillingGroup);
+        $retrievedBillingGroup = self::$billingApi->update($createdBillingGroup->getId(), $bgUpdatable);
+        $this->assertEquals("Updated Billing Group", $retrievedBillingGroup->getDescription());
+    }
+
+    public function testUpdate404()
+    {
+        $bgUpdatable = new BillingGroupEditable();
+        $bgUpdatable->setDescription("Updated Billing Group");
+        $this->expectException(ApiException::class);
+        $this->expectExceptionMessageMatches("/billing_group not found/");
+        $retrievedBillingGroup = self::$billingApi->update("bg_fakeId", $bgUpdatable);
+    }
+
+    public function testUpdate0()
+    {
+        $createdBillingGroup = self::$billingApi->create(self::$editableBillingGroup);
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches("/Missing the required parameter/");
+        $retrievedBillingGroup = self::$billingApi->update($createdBillingGroup->getId(), null);
     }
 
     // commented out some parts of this test because of a bug in the billijng groups endpoint
@@ -172,47 +162,61 @@ class BillingGroupsApiSpecTest extends TestCase
     {
         $nextUrl = "";
         $previousUrl = "";
-        try {
-            $billing1 = self::$billingApi->create(self::$bg1);
-            $billing2 = self::$billingApi->create(self::$bg2);
-            $billing3 = self::$billingApi->create(self::$bg3);
-            $listedBillingGroups = self::$billingApi->list(3);
-            $this->assertGreaterThan(1, count($listedBillingGroups->getData()));
-            $this->assertLessThanOrEqual(3, count($listedBillingGroups->getData()));
-            // $nextUrl = substr($listedBillingGroups->getNextUrl(), strrpos($listedBillingGroups->getNextUrl(), "after=") + 6);
-            // $this->assertIsString($nextUrl);
-        } catch (Exception $listError) {
-            echo 'Caught exception: ',  $listError->getMessage(), "\n";
-        }
+        $billing1 = self::$billingApi->create(self::$bg1);
+        $billing2 = self::$billingApi->create(self::$bg2);
+        $billing3 = self::$billingApi->create(self::$bg3);
+        $listedBillingGroups = self::$billingApi->list(3);
+        $this->assertGreaterThan(1, count($listedBillingGroups->getData()));
+        $this->assertLessThanOrEqual(3, count($listedBillingGroups->getData()));
+        // $nextUrl = substr($listedBillingGroups->getNextUrl(), strrpos($listedBillingGroups->getNextUrl(), "after=") + 6);
+        // $this->assertIsString($nextUrl);
 
         // // response using nextUrl
         // if ($nextUrl != "") {
-        //     try {
-        //         $billing1 = self::$billingApi->create(self::$bg1);
-        //         $billing2 = self::$billingApi->create(self::$bg2);
-        //         $billing3 = self::$billingApi->create(self::$bg3);
-        //         $listedBillingGroupsAfter = self::$billingApi->list(3, null, $nextUrl);
-        //         $this->assertGreaterThan(1, count($listedBillingGroupsAfter->getData()));
-        //         $this->assertLessThanOrEqual(3, count($listedBillingGroupsAfter->getData()));
-        //         $previousUrl = substr($listedBillingGroupsAfter->getPreviousUrl(), strrpos($listedBillingGroupsAfter->getPreviousUrl(), "before=") + 7);
-        //         $this->assertIsString($previousUrl);
-        //     } catch (Exception $listError) {
-        //         echo 'Caught exception: ',  $listError->getMessage(), "\n";
-        //     }
+        //     $billing1 = self::$billingApi->create(self::$bg1);
+        //     $billing2 = self::$billingApi->create(self::$bg2);
+        //     $billing3 = self::$billingApi->create(self::$bg3);
+        //     $listedBillingGroupsAfter = self::$billingApi->list(3, null, $nextUrl);
+        //     $this->assertGreaterThan(1, count($listedBillingGroupsAfter->getData()));
+        //     $this->assertLessThanOrEqual(3, count($listedBillingGroupsAfter->getData()));
+        //     $previousUrl = substr($listedBillingGroupsAfter->getPreviousUrl(), strrpos($listedBillingGroupsAfter->getPreviousUrl(), "before=") + 7);
+        //     $this->assertIsString($previousUrl);
         // }
 
         // // response using previousUrl
         // if ($previousUrl != "") {
-        //     try {
-        //         $billing1 = self::$billingApi->create(self::$bg1);
-        //         $billing2 = self::$billingApi->create(self::$bg2);
-        //         $billing3 = self::$billingApi->create(self::$bg3);
-        //         $listedBillingGroupsBefore = self::$billingApi->list(3, $previousUrl);
-        //         $this->assertGreaterThan(1, count($listedBillingGroupsBefore->getData()));
-        //         $this->assertLessThanOrEqual(3, count($listedBillingGroupsBefore->getData()));
-        //     } catch (Exception $listError) {
-        //         echo 'Caught exception: ',  $listError->getMessage(), "\n";
-        //     }
+        //     $billing1 = self::$billingApi->create(self::$bg1);
+        //     $billing2 = self::$billingApi->create(self::$bg2);
+        //     $billing3 = self::$billingApi->create(self::$bg3);
+        //     $listedBillingGroupsBefore = self::$billingApi->list(3, $previousUrl);
+        //     $this->assertGreaterThan(1, count($listedBillingGroupsBefore->getData()));
+        //     $this->assertLessThanOrEqual(3, count($listedBillingGroupsBefore->getData()));
         // }
+    }
+
+    public function provider()
+    {
+        return array(
+            array(null, 1, null, null, null, null),
+            // array(null, null, array("total_count"), null, null, null),
+            // array(null, null, null, array("gt" => (string)date("c"), "lt" => (string)(date("c", time() + 86400))), null, null),
+            // array(null, null, null, null, array("gt" => (string)(date("c")), "lt" => (string)(date("c", time() + 86400))), null),
+            array(null, null, null, null, null, new SortBy5(array("date_created" => "asc"))),
+        );
+    }
+
+    /**
+     * @dataProvider provider
+     */
+    public function testListWithParams($limit, $offset, $include, $date_created, $date_modified, $sort_by)
+    {
+        // create billing groups to list
+        $billing1 = self::$billingApi->create(self::$bg1);
+        $billing2 = self::$billingApi->create(self::$bg2);
+        $billing3 = self::$billingApi->create(self::$bg3);
+        $listedBillingGroups = self::$billingApi->list($limit, $offset, $include, $date_created, $date_modified, $sort_by);
+
+        $this->assertGreaterThan(0, $listedBillingGroups->getCount());
+        if ($include) $this->assertNotNull($listedBillingGroups->getTotalCount());
     }
 }

--- a/test/Integration/BillingGroupsApiSpecTest.php
+++ b/test/Integration/BillingGroupsApiSpecTest.php
@@ -196,11 +196,15 @@ class BillingGroupsApiSpecTest extends TestCase
 
     public function provider()
     {
+        date_default_timezone_set('America/Los_Angeles');
+        $date_str = date("Y-m-d", strtotime("-1 months"));
+        $date_obj = (object) array("gt" => $date_str);
+
         return array(
             array(null, 1, null, null, null, null),
             // array(null, null, array("total_count"), null, null, null),
-            // array(null, null, null, array("gt" => (string)date("c"), "lt" => (string)(date("c", time() + 86400))), null, null),
-            // array(null, null, null, null, array("gt" => (string)(date("c")), "lt" => (string)(date("c", time() + 86400))), null),
+            array(null, null, null, $date_obj, null, null),
+            array(null, null, null, null, $date_obj, null),
             array(null, null, null, null, null, new SortBy5(array("date_created" => "asc"))),
         );
     }

--- a/test/Integration/BillingGroupsApiSpecTest.php
+++ b/test/Integration/BillingGroupsApiSpecTest.php
@@ -98,8 +98,12 @@ class BillingGroupsApiSpecTest extends TestCase
 
     public function testCreate200()
     {
-        $createdBillingGroup = self::$billingApi->create(self::$editableBillingGroup);
-        $this->assertMatchesRegularExpression("/bg_/", $createdBillingGroup->getId());
+        try {
+            $createdBillingGroup = self::$billingApi->create(self::$editableBillingGroup);
+            $this->assertMatchesRegularExpression("/bg_/", $createdBillingGroup->getId());
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+        }
     }
 
     // does not include required field in request
@@ -119,9 +123,13 @@ class BillingGroupsApiSpecTest extends TestCase
 
     public function testGet200()
     {
-        $createdBillingGroup = self::$billingApi->create(self::$editableBillingGroup);
-        $retrievedBillingGroup = self::$billingApi->get($createdBillingGroup->getId());
-        $this->assertEquals($createdBillingGroup->getDescription(), $retrievedBillingGroup->getDescription());
+        try {
+            $createdBillingGroup = self::$billingApi->create(self::$editableBillingGroup);
+            $retrievedBillingGroup = self::$billingApi->get($createdBillingGroup->getId());
+            $this->assertEquals($createdBillingGroup->getDescription(), $retrievedBillingGroup->getDescription());
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+        }
     }
 
     public function testGet404()
@@ -133,11 +141,15 @@ class BillingGroupsApiSpecTest extends TestCase
 
     public function testUpdate200()
     {
-        $bgUpdatable = new BillingGroupEditable();
-        $bgUpdatable->setDescription("Updated Billing Group");
-        $createdBillingGroup = self::$billingApi->create(self::$editableBillingGroup);
-        $retrievedBillingGroup = self::$billingApi->update($createdBillingGroup->getId(), $bgUpdatable);
-        $this->assertEquals("Updated Billing Group", $retrievedBillingGroup->getDescription());
+        try {
+            $bgUpdatable = new BillingGroupEditable();
+            $bgUpdatable->setDescription("Updated Billing Group");
+            $createdBillingGroup = self::$billingApi->create(self::$editableBillingGroup);
+            $retrievedBillingGroup = self::$billingApi->update($createdBillingGroup->getId(), $bgUpdatable);
+            $this->assertEquals("Updated Billing Group", $retrievedBillingGroup->getDescription());
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+        }
     }
 
     public function testUpdate404()
@@ -157,41 +169,18 @@ class BillingGroupsApiSpecTest extends TestCase
         $retrievedBillingGroup = self::$billingApi->update($createdBillingGroup->getId(), null);
     }
 
-    // commented out some parts of this test because of a bug in the billijng groups endpoint
     public function testList200()
     {
-        $nextUrl = "";
-        $previousUrl = "";
-        $billing1 = self::$billingApi->create(self::$bg1);
-        $billing2 = self::$billingApi->create(self::$bg2);
-        $billing3 = self::$billingApi->create(self::$bg3);
-        $listedBillingGroups = self::$billingApi->list(3);
-        $this->assertGreaterThan(1, count($listedBillingGroups->getData()));
-        $this->assertLessThanOrEqual(3, count($listedBillingGroups->getData()));
-        // $nextUrl = substr($listedBillingGroups->getNextUrl(), strrpos($listedBillingGroups->getNextUrl(), "after=") + 6);
-        // $this->assertIsString($nextUrl);
-
-        // // response using nextUrl
-        // if ($nextUrl != "") {
-        //     $billing1 = self::$billingApi->create(self::$bg1);
-        //     $billing2 = self::$billingApi->create(self::$bg2);
-        //     $billing3 = self::$billingApi->create(self::$bg3);
-        //     $listedBillingGroupsAfter = self::$billingApi->list(3, null, $nextUrl);
-        //     $this->assertGreaterThan(1, count($listedBillingGroupsAfter->getData()));
-        //     $this->assertLessThanOrEqual(3, count($listedBillingGroupsAfter->getData()));
-        //     $previousUrl = substr($listedBillingGroupsAfter->getPreviousUrl(), strrpos($listedBillingGroupsAfter->getPreviousUrl(), "before=") + 7);
-        //     $this->assertIsString($previousUrl);
-        // }
-
-        // // response using previousUrl
-        // if ($previousUrl != "") {
-        //     $billing1 = self::$billingApi->create(self::$bg1);
-        //     $billing2 = self::$billingApi->create(self::$bg2);
-        //     $billing3 = self::$billingApi->create(self::$bg3);
-        //     $listedBillingGroupsBefore = self::$billingApi->list(3, $previousUrl);
-        //     $this->assertGreaterThan(1, count($listedBillingGroupsBefore->getData()));
-        //     $this->assertLessThanOrEqual(3, count($listedBillingGroupsBefore->getData()));
-        // }
+        try {
+            $billing1 = self::$billingApi->create(self::$bg1);
+            $billing2 = self::$billingApi->create(self::$bg2);
+            $billing3 = self::$billingApi->create(self::$bg3);
+            $listedBillingGroups = self::$billingApi->list(3);
+            $this->assertGreaterThan(1, count($listedBillingGroups->getData()));
+            $this->assertLessThanOrEqual(3, count($listedBillingGroups->getData()));
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+        }
     }
 
     public function provider()
@@ -214,13 +203,17 @@ class BillingGroupsApiSpecTest extends TestCase
      */
     public function testListWithParams($limit, $offset, $include, $date_created, $date_modified, $sort_by)
     {
-        // create billing groups to list
-        $billing1 = self::$billingApi->create(self::$bg1);
-        $billing2 = self::$billingApi->create(self::$bg2);
-        $billing3 = self::$billingApi->create(self::$bg3);
-        $listedBillingGroups = self::$billingApi->list($limit, $offset, $include, $date_created, $date_modified, $sort_by);
+        try {
+            // create billing groups to list
+            $billing1 = self::$billingApi->create(self::$bg1);
+            $billing2 = self::$billingApi->create(self::$bg2);
+            $billing3 = self::$billingApi->create(self::$bg3);
+            $listedBillingGroups = self::$billingApi->list($limit, $offset, $include, $date_created, $date_modified, $sort_by);
 
-        $this->assertGreaterThan(0, $listedBillingGroups->getCount());
-        if ($include) $this->assertNotNull($listedBillingGroups->getTotalCount());
+            $this->assertGreaterThan(0, $listedBillingGroups->getCount());
+            if ($include) $this->assertNotNull($listedBillingGroups->getTotalCount());
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+        }
     }
 }

--- a/test/Integration/CardOrdersApiSpecTest.php
+++ b/test/Integration/CardOrdersApiSpecTest.php
@@ -54,6 +54,7 @@ class CardOrdersApiSpecTest extends TestCase
     private static $config;
     private static $cardOrdersApi;
     private static $cardApi;
+    private static $invalidCardOrdersApi;
     private static $cardId;
     private static $editableCardOrder;
     private static $errorCardOrder;
@@ -71,7 +72,11 @@ class CardOrdersApiSpecTest extends TestCase
         self::$config = new Configuration();
         self::$config->setApiKey('basic', getenv('LOB_API_TEST_KEY'));
         self::$cardOrdersApi = new CardOrdersApi(self::$config);
-        
+
+        $invalidConfig = new Configuration();
+        $invalidConfig->setApiKey("basic", "Totally Fake Key");
+        self::$invalidCardOrdersApi = new CardOrdersApi($invalidConfig);
+
         // create a card which the card orders will be affiliated with
         self::$cardApi = new CardsApi(self::$config);
         $editableCard = new CardEditable();
@@ -103,99 +108,78 @@ class CardOrdersApiSpecTest extends TestCase
     }
 
     public function testCardOrdersApiInstantiation200() {
-        try {
-            $cardOrdersApi200 = new CardOrdersApi(self::$config);
-            $this->assertEquals(gettype($cardOrdersApi200), 'object');
-        } catch (Exception $instantiationError) {
-            echo 'Caught exception: ',  $instantiationError->getMessage(), "\n";
-        }
+        $cardOrdersApi200 = new CardOrdersApi(self::$config);
+        $this->assertEquals(gettype($cardOrdersApi200), 'object');
     }
 
     public function testCreate200()
     {
-        try {
-            $createdCardOrder = self::$cardOrdersApi->create(self::$cardId, self::$editableCardOrder);
-            $this->assertMatchesRegularExpression('/co_/', $createdCardOrder->getId());
-            array_push($this->idsForCleanup, $createdCardOrder->getId());
-        } catch (Exception $createError) {
-            echo 'Caught exception: ',  $createError->getMessage(), "\n";
-        }
+        $createdCardOrder = self::$cardOrdersApi->create(self::$cardId, self::$editableCardOrder);
+        $this->assertMatchesRegularExpression('/co_/', $createdCardOrder->getId());
+        array_push($this->idsForCleanup, $createdCardOrder->getId());
     }
 
     // does not include required field in request
     public function testCreate422()
     {
-        
-        try {
-            $this->expectException(ApiException::class);
-            $this->expectExceptionMessageMatches("/Number of cards in order must be at least 10000/");
-            $errorResponse = self::$cardOrdersApi->create(self::$cardId, self::$errorCardOrder);
-        } catch (Exception $createError) {
-            echo 'Caught exception: ',  $createError->getMessage(), "\n";
-        }
+
+        $this->expectException(ApiException::class);
+        $this->expectExceptionMessageMatches("/Number of cards in order must be at least 10000/");
+        $errorResponse = self::$cardOrdersApi->create(self::$cardId, self::$errorCardOrder);
     }
 
     // uses a bad key to attempt to send a request
     public function testCardOrdersApi401() {
-        try {
-            $wrongConfig = new Configuration();
-            $wrongConfig->setApiKey('basic', 'BAD KEY');
-            $cardOrdersApiError = new CardOrdersApi($wrongConfig);
+        $wrongConfig = new Configuration();
+        $wrongConfig->setApiKey('basic', 'BAD KEY');
+        $cardOrdersApiError = new CardOrdersApi($wrongConfig);
 
-            $this->expectException(ApiException::class);
-            $this->expectExceptionMessageMatches("/Your API key is not valid. Please sign up on lob.com to get a valid api key./");
-            $errorResponse = $cardOrdersApiError->create(self::$cardId, self::$editableCardOrder);
-        } catch (Exception $instantiationError) {
-            echo 'Caught exception: ',  $instantiationError->getMessage(), "\n";
-        }
+        $this->expectException(ApiException::class);
+        $this->expectExceptionMessageMatches("/Your API key is not valid. Please sign up on lob.com to get a valid api key./");
+        $errorResponse = $cardOrdersApiError->create(self::$cardId, self::$editableCardOrder);
     }
 
     public function testRetrieve200()
     {
-        $this->markTestSkipped("Cannot properly test this until the SDK is regenerated and all bugs are solved");
-        $nextUrl = "";
-        $previousUrl = "";
-        try {
-            $cardOrder1 = self::$cardOrdersApi->create(self::$cardId, self::$co1);
-            $cardOrder2 = self::$cardOrdersApi->create(self::$cardId, self::$co2);
-            $cardOrder3 = self::$cardOrdersApi->create(self::$cardId, self::$co3);
-            $listedCardOrders = self::$cardOrdersApi->get(self::$cardId);
-            $this->assertGreaterThan(1, count($listedCardOrders->getData()));
-            $this->assertLessThanOrEqual(3, count($listedCardOrders->getData()));
-            $nextUrl = substr($listedCardOrders->getNextUrl(), strrpos($listedCardOrders->getNextUrl(), "after=") + 6);
-            $this->assertIsString($nextUrl);
-        } catch (Exception $listError) {
-            echo 'Caught exception: ',  $listError->getMessage(), "\n";
-        }
+        $cardOrder1 = self::$cardOrdersApi->create(self::$cardId, self::$co1);
+        $cardOrder2 = self::$cardOrdersApi->create(self::$cardId, self::$co2);
+        $cardOrder3 = self::$cardOrdersApi->create(self::$cardId, self::$co3);
+        $cardOrder4 = self::$cardOrdersApi->create(self::$cardId, self::$co1);
+        $cardOrder5 = self::$cardOrdersApi->create(self::$cardId, self::$co2);
+        $cardOrder6 = self::$cardOrdersApi->create(self::$cardId, self::$co3);
 
-        // response using nextUrl
-        if ($nextUrl != "") {
-            try {
-                $cardOrder1 = self::$cardOrdersApi->create(self::$cardId, self::$co1);
-                $cardOrder2 = self::$cardOrdersApi->create(self::$cardId, self::$co2);
-                $cardOrder3 = self::$cardOrdersApi->create(self::$cardId, self::$co3);
-                $listedCardsAfter = self::$cardOrdersApi->get(3, null, $nextUrl);
-                $this->assertGreaterThan(1, count($listedCardsAfter->getData()));
-                $this->assertLessThanOrEqual(3, count($listedCardsAfter->getData()));
-                $previousUrl = substr($listedCardsAfter->getPreviousUrl(), strrpos($listedCardsAfter->getPreviousUrl(), "before=") + 7);
-                $this->assertIsString($previousUrl);
-            } catch (Exception $listError) {
-                echo 'Caught exception: ',  $listError->getMessage(), "\n";
-            }
-        }
+        $listedCardOrders = self::$cardOrdersApi->get(self::$cardId, 6);
+        $this->assertGreaterThan(1, count($listedCardOrders->getData()));
+        $this->assertLessThanOrEqual(6, count($listedCardOrders->getData()));
+        $this->assertEquals(count($listedCardOrders->getData()), $listedCardOrders->getCount());
 
-        // response using previousUrl
-        if ($previousUrl != "") {
-            try {
-                $cardOrder1 = self::$cardOrdersApi->create(self::$cardId, self::$co1);
-                $cardOrder2 = self::$cardOrdersApi->create(self::$cardId, self::$co2);
-                $cardOrder3 = self::$cardOrdersApi->create(self::$cardId, self::$co3);
-                $listedCardsBefore = self::$cardOrdersApi->get(3, $previousUrl);
-                $this->assertGreaterThan(1, count($listedCardsBefore->getData()));
-                $this->assertLessThanOrEqual(3, count($listedCardsBefore->getData()));
-            } catch (Exception $listError) {
-                echo 'Caught exception: ',  $listError->getMessage(), "\n";
-            }
+        // response using offset
+        $listCardOrders = [$cardOrder3, $cardOrder2, $cardOrder1]; // they'll be listed from newest to oldest
+        $listedCardsAfter = self::$cardOrdersApi->get(self::$cardId, 3, 3);
+
+        for ($ind = 0; $ind < 3; $ind++) {
+            $this->assertEquals($listedCardsAfter->getData()[$ind]->getId(), $listCardOrders[$ind]->getId());
         }
+    }
+
+    // uses a bad key to attempt to send a request
+    public function testBillingGroupApi401() {
+        $this->expectException(ApiException::class);
+        $this->expectExceptionMessageMatches("/Your API key is not valid. Please sign up on lob.com to get a valid api key./");
+        $errorResponse = self::$invalidCardOrdersApi->get(self::$cardId);
+    }
+
+    public function testRetrieve404()
+    {
+        $this->expectException(ApiException::class);
+        $this->expectExceptionMessageMatches("/card not found/");
+        $badRetrieval = self::$cardOrdersApi->get("card_fakeId");
+    }
+
+    public function testRetrieve0()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches("/Missing the required parameter/");
+        $badRetrieval = self::$cardOrdersApi->get(null);
     }
 }

--- a/test/Integration/CardOrdersApiSpecTest.php
+++ b/test/Integration/CardOrdersApiSpecTest.php
@@ -108,21 +108,28 @@ class CardOrdersApiSpecTest extends TestCase
     }
 
     public function testCardOrdersApiInstantiation200() {
-        $cardOrdersApi200 = new CardOrdersApi(self::$config);
-        $this->assertEquals(gettype($cardOrdersApi200), 'object');
+        try {
+            $cardOrdersApi200 = new CardOrdersApi(self::$config);
+            $this->assertEquals(gettype($cardOrdersApi200), 'object');
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+        }
     }
 
     public function testCreate200()
     {
-        $createdCardOrder = self::$cardOrdersApi->create(self::$cardId, self::$editableCardOrder);
-        $this->assertMatchesRegularExpression('/co_/', $createdCardOrder->getId());
-        array_push($this->idsForCleanup, $createdCardOrder->getId());
+        try {
+            $createdCardOrder = self::$cardOrdersApi->create(self::$cardId, self::$editableCardOrder);
+            $this->assertMatchesRegularExpression('/co_/', $createdCardOrder->getId());
+            array_push($this->idsForCleanup, $createdCardOrder->getId());
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+        }
     }
 
     // does not include required field in request
     public function testCreate422()
     {
-
         $this->expectException(ApiException::class);
         $this->expectExceptionMessageMatches("/Number of cards in order must be at least 10000/");
         $errorResponse = self::$cardOrdersApi->create(self::$cardId, self::$errorCardOrder);
@@ -141,32 +148,29 @@ class CardOrdersApiSpecTest extends TestCase
 
     public function testRetrieve200()
     {
-        $cardOrder1 = self::$cardOrdersApi->create(self::$cardId, self::$co1);
-        $cardOrder2 = self::$cardOrdersApi->create(self::$cardId, self::$co2);
-        $cardOrder3 = self::$cardOrdersApi->create(self::$cardId, self::$co3);
-        $cardOrder4 = self::$cardOrdersApi->create(self::$cardId, self::$co1);
-        $cardOrder5 = self::$cardOrdersApi->create(self::$cardId, self::$co2);
-        $cardOrder6 = self::$cardOrdersApi->create(self::$cardId, self::$co3);
+        try {
+            $cardOrder1 = self::$cardOrdersApi->create(self::$cardId, self::$co1);
+            $cardOrder2 = self::$cardOrdersApi->create(self::$cardId, self::$co2);
+            $cardOrder3 = self::$cardOrdersApi->create(self::$cardId, self::$co3);
+            $cardOrder4 = self::$cardOrdersApi->create(self::$cardId, self::$co1);
+            $cardOrder5 = self::$cardOrdersApi->create(self::$cardId, self::$co2);
+            $cardOrder6 = self::$cardOrdersApi->create(self::$cardId, self::$co3);
 
-        $listedCardOrders = self::$cardOrdersApi->get(self::$cardId, 6);
-        $this->assertGreaterThan(1, count($listedCardOrders->getData()));
-        $this->assertLessThanOrEqual(6, count($listedCardOrders->getData()));
-        $this->assertEquals(count($listedCardOrders->getData()), $listedCardOrders->getCount());
+            $listedCardOrders = self::$cardOrdersApi->get(self::$cardId, 6);
+            $this->assertGreaterThan(1, count($listedCardOrders->getData()));
+            $this->assertLessThanOrEqual(6, count($listedCardOrders->getData()));
+            $this->assertEquals(count($listedCardOrders->getData()), $listedCardOrders->getCount());
 
-        // response using offset
-        $listCardOrders = [$cardOrder3, $cardOrder2, $cardOrder1]; // they'll be listed from newest to oldest
-        $listedCardsAfter = self::$cardOrdersApi->get(self::$cardId, 3, 3);
+            // response using offset
+            $listCardOrders = [$cardOrder3, $cardOrder2, $cardOrder1]; // they'll be listed from newest to oldest
+            $listedCardsAfter = self::$cardOrdersApi->get(self::$cardId, 3, 3);
 
-        for ($ind = 0; $ind < 3; $ind++) {
-            $this->assertEquals($listedCardsAfter->getData()[$ind]->getId(), $listCardOrders[$ind]->getId());
+            for ($ind = 0; $ind < 3; $ind++) {
+                $this->assertEquals($listedCardsAfter->getData()[$ind]->getId(), $listCardOrders[$ind]->getId());
+            }
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
         }
-    }
-
-    // uses a bad key to attempt to send a request
-    public function testBillingGroupApi401() {
-        $this->expectException(ApiException::class);
-        $this->expectExceptionMessageMatches("/Your API key is not valid. Please sign up on lob.com to get a valid api key./");
-        $errorResponse = self::$invalidCardOrdersApi->get(self::$cardId);
     }
 
     public function testRetrieve404()

--- a/test/Integration/CardsApiSpecTest.php
+++ b/test/Integration/CardsApiSpecTest.php
@@ -107,15 +107,23 @@ class CardsApiSpecTest extends TestCase
     }
 
     public function testCardsApiInstantiation200() {
-        $cardApi200 = new CardsApi(self::$config);
-        $this->assertEquals(gettype($cardApi200), 'object');
+        try {
+            $cardApi200 = new CardsApi(self::$config);
+            $this->assertEquals(gettype($cardApi200), 'object');
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+        }
     }
 
     public function testCreate200()
     {
-        $createdCard = self::$cardApi->create(self::$editableCard);
-        $this->assertMatchesRegularExpression('/card_/', $createdCard->getId());
-        array_push($this->idsForCleanup, $createdCard->getId());
+        try {
+            $createdCard = self::$cardApi->create(self::$editableCard);
+            $this->assertMatchesRegularExpression('/card_/', $createdCard->getId());
+            array_push($this->idsForCleanup, $createdCard->getId());
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+        }
     }
 
     // uses a bad key to attempt to send a request
@@ -135,10 +143,14 @@ class CardsApiSpecTest extends TestCase
 
     public function testGet200()
     {
-        $createdCard = self::$cardApi->create(self::$editableCard);
-        $retrievedCard = self::$cardApi->get($createdCard->getId());
-        $this->assertEquals($createdCard->getDescription(), $retrievedCard->getDescription());
-        array_push($this->idsForCleanup, $createdCard->getId());
+        try {
+            $createdCard = self::$cardApi->create(self::$editableCard);
+            $retrievedCard = self::$cardApi->get($createdCard->getId());
+            $this->assertEquals($createdCard->getDescription(), $retrievedCard->getDescription());
+            array_push($this->idsForCleanup, $createdCard->getId());
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+        }
     }
 
     public function testGet0()
@@ -168,12 +180,16 @@ class CardsApiSpecTest extends TestCase
 
     public function testUpdate200()
     {
-        $cardUpdatable = new CardUpdatable();
-        $cardUpdatable->setDescription("Updated Card");
-        $createdCard = self::$cardApi->create(self::$editableCard);
-        $retrievedCard = self::$cardApi->update($createdCard->getId(), $cardUpdatable);
-        $this->assertEquals("Updated Card", $retrievedCard->getDescription());
-        array_push($this->idsForCleanup, $createdCard->getId());
+        try {
+            $cardUpdatable = new CardUpdatable();
+            $cardUpdatable->setDescription("Updated Card");
+            $createdCard = self::$cardApi->create(self::$editableCard);
+            $retrievedCard = self::$cardApi->update($createdCard->getId(), $cardUpdatable);
+            $this->assertEquals("Updated Card", $retrievedCard->getDescription());
+            array_push($this->idsForCleanup, $createdCard->getId());
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+        }
     }
 
     public function testUpdate0()
@@ -210,70 +226,90 @@ class CardsApiSpecTest extends TestCase
         $nextUrl = "";
         $previousUrl = "";
 
-        $cr1 = self::$cardApi->create(self::$card1);
-        $cr2 = self::$cardApi->create(self::$card2);
-        $cr3 = self::$cardApi->create(self::$card3);
-        $listedCards = self::$cardApi->list(3);
-        $this->assertGreaterThan(1, count($listedCards->getData()));
-        $this->assertLessThanOrEqual(3, count($listedCards->getData()));
-        $nextUrl = substr($listedCards->getNextUrl(), strrpos($listedCards->getNextUrl(), "after=") + 6);
-        $this->assertIsString($nextUrl);
-        array_push($this->idsForCleanup, $cr1->getId());
-        array_push($this->idsForCleanup, $cr2->getId());
-        array_push($this->idsForCleanup, $cr3->getId());
-
-        // response using nextUrl
-        if ($nextUrl != "") {
+        try {
             $cr1 = self::$cardApi->create(self::$card1);
             $cr2 = self::$cardApi->create(self::$card2);
             $cr3 = self::$cardApi->create(self::$card3);
-            $listedCardsAfter = self::$cardApi->list(3, null, $nextUrl);
-            $this->assertGreaterThan(1, count($listedCardsAfter->getData()));
-            $this->assertLessThanOrEqual(3, count($listedCardsAfter->getData()));
-            $previousUrl = substr($listedCardsAfter->getPreviousUrl(), strrpos($listedCardsAfter->getPreviousUrl(), "before=") + 7);
-            $this->assertIsString($previousUrl);
+            $listedCards = self::$cardApi->list(3);
+            $this->assertGreaterThan(1, count($listedCards->getData()));
+            $this->assertLessThanOrEqual(3, count($listedCards->getData()));
+            $nextUrl = substr($listedCards->getNextUrl(), strrpos($listedCards->getNextUrl(), "after=") + 6);
+            $this->assertIsString($nextUrl);
             array_push($this->idsForCleanup, $cr1->getId());
             array_push($this->idsForCleanup, $cr2->getId());
             array_push($this->idsForCleanup, $cr3->getId());
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+        }
+
+        // response using nextUrl
+        if ($nextUrl != "") {
+            try {
+                $cr1 = self::$cardApi->create(self::$card1);
+                $cr2 = self::$cardApi->create(self::$card2);
+                $cr3 = self::$cardApi->create(self::$card3);
+                $listedCardsAfter = self::$cardApi->list(3, null, $nextUrl);
+                $this->assertGreaterThan(1, count($listedCardsAfter->getData()));
+                $this->assertLessThanOrEqual(3, count($listedCardsAfter->getData()));
+                $previousUrl = substr($listedCardsAfter->getPreviousUrl(), strrpos($listedCardsAfter->getPreviousUrl(), "before=") + 7);
+                $this->assertIsString($previousUrl);
+                array_push($this->idsForCleanup, $cr1->getId());
+                array_push($this->idsForCleanup, $cr2->getId());
+                array_push($this->idsForCleanup, $cr3->getId());
+            } catch (\Exception $e) {
+                throw new \Exception($e->getMessage());
+            }
         }
 
         // response using previousUrl
         if ($previousUrl != "") {
-            $cr1 = self::$cardApi->create(self::$card1);
-            $cr2 = self::$cardApi->create(self::$card2);
-            $cr3 = self::$cardApi->create(self::$card3);
-            $listedCardsBefore = self::$cardApi->list(3, $previousUrl);
-            $this->assertGreaterThan(1, count($listedCardsBefore->getData()));
-            $this->assertLessThanOrEqual(3, count($listedCardsBefore->getData()));
-            array_push($this->idsForCleanup, $cr1->getId());
-            array_push($this->idsForCleanup, $cr2->getId());
-            array_push($this->idsForCleanup, $cr3->getId());
+            try {
+                $cr1 = self::$cardApi->create(self::$card1);
+                $cr2 = self::$cardApi->create(self::$card2);
+                $cr3 = self::$cardApi->create(self::$card3);
+                $listedCardsBefore = self::$cardApi->list(3, $previousUrl);
+                $this->assertGreaterThan(1, count($listedCardsBefore->getData()));
+                $this->assertLessThanOrEqual(3, count($listedCardsBefore->getData()));
+                array_push($this->idsForCleanup, $cr1->getId());
+                array_push($this->idsForCleanup, $cr2->getId());
+                array_push($this->idsForCleanup, $cr3->getId());
+            } catch (\Exception $e) {
+                throw new \Exception($e->getMessage());
+            }
         }
     }
 
     public function testListWithSortByParam()
     {
         $this->markTestSkipped("Cannot properly test this until the SDK is regenerated and all bugs are solved");
-        // create bank accounts to list
-        $cr1 = self::$cardApi->create(self::$card1);
-        $cr2 = self::$cardApi->create(self::$card2);
-        $cr3 = self::$cardApi->create(self::$card3);
-        $listedCards = self::$cardApi->list(10, null, null, new SortBy5(array("date_created" => "asc")));
+        try {
+            // create bank accounts to list
+            $cr1 = self::$cardApi->create(self::$card1);
+            $cr2 = self::$cardApi->create(self::$card2);
+            $cr3 = self::$cardApi->create(self::$card3);
+            $listedCards = self::$cardApi->list(10, null, null, new SortBy5(array("date_created" => "asc")));
 
-        $this->assertGreaterThan(0, $listedCards->getCount());
+            $this->assertGreaterThan(0, $listedCards->getCount());
 
-        // delete created bank accounts
-        array_push($this->idsForCleanup, $cr1->getId());
-        array_push($this->idsForCleanup, $cr2->getId());
-        array_push($this->idsForCleanup, $cr3->getId());
+            // delete created bank accounts
+            array_push($this->idsForCleanup, $cr1->getId());
+            array_push($this->idsForCleanup, $cr2->getId());
+            array_push($this->idsForCleanup, $cr3->getId());
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+        }
     }
 
     public function testDelete200()
     {
-        $createdCard = self::$cardApi->create(self::$editableCard);
-        $deletedCard = self::$cardApi->delete($createdCard->getId());
-        $this->assertEquals(true, $deletedCard->getDeleted());
-        $this->assertMatchesRegularExpression('/card_/', $deletedCard->getId());
+        try {
+            $createdCard = self::$cardApi->create(self::$editableCard);
+            $deletedCard = self::$cardApi->delete($createdCard->getId());
+            $this->assertEquals(true, $deletedCard->getDeleted());
+            $this->assertMatchesRegularExpression('/card_/', $deletedCard->getId());
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+        }
     }
 
     public function testDelete401()

--- a/test/Integration/CardsApiSpecTest.php
+++ b/test/Integration/CardsApiSpecTest.php
@@ -34,6 +34,7 @@ use PHPUnit\Framework\TestCase;
 use \OpenAPI\Client\Model\CardEditable;
 use \OpenAPI\Client\Model\CardUpdatable;
 use \OpenAPI\Client\Api\CardsApi;
+use \OpenAPI\Client\Model\SortBy5;
 
 /**
  * CardsApiSpecTest Class Doc Comment
@@ -51,6 +52,7 @@ class CardsApiSpecTest extends TestCase
      */
     private static $config;
     private static $cardApi;
+    private static $invalidCardApi;
     private static $editableCard;
     private static $errorCard;
     private static $card1;
@@ -67,6 +69,10 @@ class CardsApiSpecTest extends TestCase
         self::$config = new Configuration();
         self::$config->setApiKey('basic', getenv('LOB_API_TEST_KEY'));
         self::$cardApi = new CardsApi(self::$config);
+
+        $invalid_config = new Configuration();
+        $invalid_config->setApiKey("basic", "Totally Fake Key");
+        self::$invalidCardApi = new CardsApi($invalid_config);
 
         self::$editableCard = new CardEditable();
         self::$editableCard->setFront("https://s3-us-west-2.amazonaws.com/public.lob.com/assets/card_horizontal.pdf");
@@ -101,167 +107,189 @@ class CardsApiSpecTest extends TestCase
     }
 
     public function testCardsApiInstantiation200() {
-        try {
-            $cardApi200 = new CardsApi(self::$config);
-            $this->assertEquals(gettype($cardApi200), 'object');
-        } catch (Exception $instantiationError) {
-            echo 'Caught exception: ',  $instantiationError->getMessage(), "\n";
-        }
+        $cardApi200 = new CardsApi(self::$config);
+        $this->assertEquals(gettype($cardApi200), 'object');
     }
 
     public function testCreate200()
     {
-        try {
-            $createdCard = self::$cardApi->create(self::$editableCard);
-            $this->assertMatchesRegularExpression('/card_/', $createdCard->getId());
-            array_push($this->idsForCleanup, $createdCard->getId());
-        } catch (Exception $createError) {
-            echo 'Caught exception: ',  $createError->getMessage(), "\n";
-        }
+        $createdCard = self::$cardApi->create(self::$editableCard);
+        $this->assertMatchesRegularExpression('/card_/', $createdCard->getId());
+        array_push($this->idsForCleanup, $createdCard->getId());
+    }
+
+    // uses a bad key to attempt to send a request
+    public function testCreate401() {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessageMatches("/Your API key is not valid. Please sign up on lob.com to get a valid api key./");
+        $errorResponse = self::$invalidCardApi->create(self::$editableCard);
     }
 
     // does not include required field in request
     public function testCreate422()
     {
-        
-        try {
-            $this->expectException(ApiException::class);
-            $this->expectExceptionMessageMatches("/front is required/");
-            $errorResponse = self::$cardApi->create(self::$errorCard);
-        } catch (Exception $createError) {
-            echo 'Caught exception: ',  $createError->getMessage(), "\n";
-        }
-    }
-
-    // uses a bad key to attempt to send a request
-    public function testCardApi401() {
-        try {
-            $wrongConfig = new Configuration();
-            $wrongConfig->setApiKey('basic', 'BAD KEY');
-            $cardApiError = new CardsApi($wrongConfig);
-
-            $this->expectException(ApiException::class);
-            $this->expectExceptionMessageMatches("/Your API key is not valid. Please sign up on lob.com to get a valid api key./");
-            $errorResponse = $cardApiError->create(self::$editableCard);
-        } catch (Exception $instantiationError) {
-            echo 'Caught exception: ',  $instantiationError->getMessage(), "\n";
-        }
+        $this->expectException(ApiException::class);
+        $this->expectExceptionMessageMatches("/front is required/");
+        $errorResponse = self::$cardApi->create(self::$errorCard);
     }
 
     public function testGet200()
     {
-        try {
-            $createdCard = self::$cardApi->create(self::$editableCard);
-            $retrievedCard = self::$cardApi->get($createdCard->getId());
-            $this->assertEquals($createdCard->getDescription(), $retrievedCard->getDescription());
-            array_push($this->idsForCleanup, $createdCard->getId());
-        } catch (Exception $retrieveError) {
-            echo 'Caught exception: ',  $retrieveError->getMessage(), "\n";
-        }
+        $createdCard = self::$cardApi->create(self::$editableCard);
+        $retrievedCard = self::$cardApi->get($createdCard->getId());
+        $this->assertEquals($createdCard->getDescription(), $retrievedCard->getDescription());
+        array_push($this->idsForCleanup, $createdCard->getId());
     }
+
+    public function testGet0()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches("/Missing the required parameter/");
+        $cardRetrieval = self::$cardApi->get(null);
+    }
+
+    public function testGet401()
+    {
+        $createdCard = self::$cardApi->create(self::$editableCard);
+        array_push($this->idsForCleanup, $createdCard->getId());
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessageMatches("/Your API key is not valid/");
+        $badRetrieval = self::$invalidCardApi->get($createdCard->getId());
+    }
+
 
     public function testGet404()
     {
-        try {
-            $this->expectException(ApiException::class);
-            $this->expectExceptionMessageMatches("/card not found/");
-            $badRetrieval = self::$cardApi->get("card_NONEXISTENT");
-        } catch (Exception $retrieveError) {
-            echo 'Caught exception: ',  $retrieveError->getMessage(), "\n";
-        }
+        $this->expectException(ApiException::class);
+        $this->expectExceptionMessageMatches("/card not found/");
+        $cardRetrieval = self::$cardApi->get("card_NONEXISTENT");
     }
 
     public function testUpdate200()
     {
-        try {
-            $cardUpdatable = new CardUpdatable();
-            $cardUpdatable->setDescription("Updated Card");
-            $createdCard = self::$cardApi->create(self::$editableCard);
-            $retrievedCard = self::$cardApi->update($createdCard->getId(), $cardUpdatable);
-            $this->assertEquals("Updated Card", $retrievedCard->getDescription());
-            array_push($this->idsForCleanup, $createdCard->getId());
-        } catch (Exception $retrieveError) {
-            echo 'Caught exception: ',  $retrieveError->getMessage(), "\n";
-        }
+        $cardUpdatable = new CardUpdatable();
+        $cardUpdatable->setDescription("Updated Card");
+        $createdCard = self::$cardApi->create(self::$editableCard);
+        $retrievedCard = self::$cardApi->update($createdCard->getId(), $cardUpdatable);
+        $this->assertEquals("Updated Card", $retrievedCard->getDescription());
+        array_push($this->idsForCleanup, $createdCard->getId());
+    }
+
+    public function testUpdate0()
+    {
+        $cardUpdatable = new CardUpdatable();
+        $cardUpdatable->setDescription("Updated Card");
+        $createdCard = self::$cardApi->create(self::$editableCard);
+        array_push($this->idsForCleanup, $createdCard->getId());
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches("/Missing the required parameter/");
+        $retrievedCard = self::$cardApi->update($createdCard->getId(), null);
+    }
+
+    public function testUpdate401()
+    {
+        $createdCard = self::$cardApi->create(self::$editableCard);
+        array_push($this->idsForCleanup, $createdCard->getId());
+
+        $this->expectException(ApiException::class);
+        $this->expectExceptionMessageMatches("/Your API key is not valid. Please sign up on lob.com to get a valid api key./");
+        $retrievedCard = self::$invalidCardApi->update($createdCard->getId(), new CardUpdatable());
+    }
+
+    public function testUpdate404()
+    {
+        $this->expectException(ApiException::class);
+        $this->expectExceptionMessageMatches("/card not found/");
+        $retrievedCard = self::$cardApi->update("card_fakeId", new CardUpdatable());
     }
 
     public function testList200()
     {
         $nextUrl = "";
         $previousUrl = "";
-        try {
-            $cr1 = self::$cardApi->create(self::$card1);
-            $cr2 = self::$cardApi->create(self::$card2);
-            $cr3 = self::$cardApi->create(self::$card3);
-            $listedCards = self::$cardApi->list(3);
-            $this->assertGreaterThan(1, count($listedCards->getData()));
-            $this->assertLessThanOrEqual(3, count($listedCards->getData()));
-            $nextUrl = substr($listedCards->getNextUrl(), strrpos($listedCards->getNextUrl(), "after=") + 6);
-            $this->assertIsString($nextUrl);
-            array_push($this->idsForCleanup, $cr1->getId());
-            array_push($this->idsForCleanup, $cr2->getId());
-            array_push($this->idsForCleanup, $cr3->getId());
-        } catch (Exception $listError) {
-            echo 'Caught exception: ',  $listError->getMessage(), "\n";
-        }
+
+        $cr1 = self::$cardApi->create(self::$card1);
+        $cr2 = self::$cardApi->create(self::$card2);
+        $cr3 = self::$cardApi->create(self::$card3);
+        $listedCards = self::$cardApi->list(3);
+        $this->assertGreaterThan(1, count($listedCards->getData()));
+        $this->assertLessThanOrEqual(3, count($listedCards->getData()));
+        $nextUrl = substr($listedCards->getNextUrl(), strrpos($listedCards->getNextUrl(), "after=") + 6);
+        $this->assertIsString($nextUrl);
+        array_push($this->idsForCleanup, $cr1->getId());
+        array_push($this->idsForCleanup, $cr2->getId());
+        array_push($this->idsForCleanup, $cr3->getId());
 
         // response using nextUrl
         if ($nextUrl != "") {
-            try {
-                $cr1 = self::$cardApi->create(self::$card1);
-                $cr2 = self::$cardApi->create(self::$card2);
-                $cr3 = self::$cardApi->create(self::$card3);
-                $listedCardsAfter = self::$cardApi->list(3, null, $nextUrl);
-                $this->assertGreaterThan(1, count($listedCardsAfter->getData()));
-                $this->assertLessThanOrEqual(3, count($listedCardsAfter->getData()));
-                $previousUrl = substr($listedCardsAfter->getPreviousUrl(), strrpos($listedCardsAfter->getPreviousUrl(), "before=") + 7);
-                $this->assertIsString($previousUrl);
-                array_push($this->idsForCleanup, $cr1->getId());
-                array_push($this->idsForCleanup, $cr2->getId());
-                array_push($this->idsForCleanup, $cr3->getId());
-            } catch (Exception $listError) {
-                echo 'Caught exception: ',  $listError->getMessage(), "\n";
-            }
+            $cr1 = self::$cardApi->create(self::$card1);
+            $cr2 = self::$cardApi->create(self::$card2);
+            $cr3 = self::$cardApi->create(self::$card3);
+            $listedCardsAfter = self::$cardApi->list(3, null, $nextUrl);
+            $this->assertGreaterThan(1, count($listedCardsAfter->getData()));
+            $this->assertLessThanOrEqual(3, count($listedCardsAfter->getData()));
+            $previousUrl = substr($listedCardsAfter->getPreviousUrl(), strrpos($listedCardsAfter->getPreviousUrl(), "before=") + 7);
+            $this->assertIsString($previousUrl);
+            array_push($this->idsForCleanup, $cr1->getId());
+            array_push($this->idsForCleanup, $cr2->getId());
+            array_push($this->idsForCleanup, $cr3->getId());
         }
 
         // response using previousUrl
         if ($previousUrl != "") {
-            try {
-                $cr1 = self::$cardApi->create(self::$card1);
-                $cr2 = self::$cardApi->create(self::$card2);
-                $cr3 = self::$cardApi->create(self::$card3);
-                $listedCardsBefore = self::$cardApi->list(3, $previousUrl);
-                $this->assertGreaterThan(1, count($listedCardsBefore->getData()));
-                $this->assertLessThanOrEqual(3, count($listedCardsBefore->getData()));
-                array_push($this->idsForCleanup, $cr1->getId());
-                array_push($this->idsForCleanup, $cr2->getId());
-                array_push($this->idsForCleanup, $cr3->getId());
-            } catch (Exception $listError) {
-                echo 'Caught exception: ',  $listError->getMessage(), "\n";
-            }
+            $cr1 = self::$cardApi->create(self::$card1);
+            $cr2 = self::$cardApi->create(self::$card2);
+            $cr3 = self::$cardApi->create(self::$card3);
+            $listedCardsBefore = self::$cardApi->list(3, $previousUrl);
+            $this->assertGreaterThan(1, count($listedCardsBefore->getData()));
+            $this->assertLessThanOrEqual(3, count($listedCardsBefore->getData()));
+            array_push($this->idsForCleanup, $cr1->getId());
+            array_push($this->idsForCleanup, $cr2->getId());
+            array_push($this->idsForCleanup, $cr3->getId());
         }
+    }
+
+    public function testListWithSortByParam()
+    {
+        $this->markTestSkipped("Cannot properly test this until the SDK is regenerated and all bugs are solved");
+        // create bank accounts to list
+        $cr1 = self::$cardApi->create(self::$card1);
+        $cr2 = self::$cardApi->create(self::$card2);
+        $cr3 = self::$cardApi->create(self::$card3);
+        $listedCards = self::$cardApi->list(10, null, null, new SortBy5(array("date_created" => "asc")));
+
+        $this->assertGreaterThan(0, $listedCards->getCount());
+
+        // delete created bank accounts
+        array_push($this->idsForCleanup, $cr1->getId());
+        array_push($this->idsForCleanup, $cr2->getId());
+        array_push($this->idsForCleanup, $cr3->getId());
     }
 
     public function testDelete200()
     {
-        try {
-            $createdCard = self::$cardApi->create(self::$editableCard);
-            $deletedCard = self::$cardApi->delete($createdCard->getId());
-            $this->assertEquals(true, $deletedCard->getDeleted());
-            $this->assertMatchesRegularExpression('/card_/', $deletedCard->getId());
-        } catch (Exception $deleteError) {
-            echo 'Caught exception: ',  $deleteError->getMessage(), "\n";
-        }
+        $createdCard = self::$cardApi->create(self::$editableCard);
+        $deletedCard = self::$cardApi->delete($createdCard->getId());
+        $this->assertEquals(true, $deletedCard->getDeleted());
+        $this->assertMatchesRegularExpression('/card_/', $deletedCard->getId());
+    }
+
+    public function testDelete401()
+    {
+        $createdCard = self::$cardApi->create(self::$editableCard);
+        array_push($this->idsForCleanup, $createdCard->getId());
+
+        $this->expectException(ApiException::class);
+        $this->expectExceptionMessageMatches("/Your API key is not valid. Please sign up on lob.com to get a valid api key./");
+        $deletedCard = self::$invalidCardApi->delete($createdCard->getId());
     }
 
     public function testDelete404()
     {
-        try {
-            $this->expectException(ApiException::class);
-            $this->expectExceptionMessageMatches("/card not found/");
-            $badDeletion = self::$cardApi->delete("card_NONEXISTENT");
-        } catch (Exception $retrieveError) {
-            echo 'Caught exception: ',  $retrieveError->getMessage(), "\n";
-        }
+        $this->expectException(ApiException::class);
+        $this->expectExceptionMessageMatches("/card not found/");
+        $cardDeletion = self::$cardApi->delete("card_NONEXISTENT");
     }
 }

--- a/test/Integration/ChecksApiSpecTest.php
+++ b/test/Integration/ChecksApiSpecTest.php
@@ -186,15 +186,23 @@ class ChecksApiSpecTest extends TestCase
 
     // include static cleanup for all the checks?
     public function testChecksApiInstantiation200() {
-        $checksApi200 = new ChecksApi(self::$config);
-        $this->assertEquals(gettype($checksApi200), "object");
+        try {
+            $checksApi200 = new ChecksApi(self::$config);
+            $this->assertEquals(gettype($checksApi200), "object");
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+        }
     }
 
     public function testCreate200()
     {
-        $createdCheck = self::$checksApi->create(self::$editableCheck);
-        $this->assertMatchesRegularExpression("/chk_/", $createdCheck->getId());
-        array_push($this->idsForCleanup, $createdCheck->getId());
+        try {
+            $createdCheck = self::$checksApi->create(self::$editableCheck);
+            $this->assertMatchesRegularExpression("/chk_/", $createdCheck->getId());
+            array_push($this->idsForCleanup, $createdCheck->getId());
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+        }
     }
 
     // does not include required field in request
@@ -218,10 +226,14 @@ class ChecksApiSpecTest extends TestCase
 
     public function testGet200()
     {
-        $createdCheck = self::$checksApi->create(self::$editableCheck);
-        $retrievedCheck = self::$checksApi->get($createdCheck->getId());
-        $this->assertEquals($createdCheck->getTo(), $retrievedCheck->getTo());
-        array_push($this->idsForCleanup, $createdCheck->getId());
+        try {
+            $createdCheck = self::$checksApi->create(self::$editableCheck);
+            $retrievedCheck = self::$checksApi->get($createdCheck->getId());
+            $this->assertEquals($createdCheck->getTo(), $retrievedCheck->getTo());
+            array_push($this->idsForCleanup, $createdCheck->getId());
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+        }
     }
 
     public function testGet0()
@@ -253,38 +265,50 @@ class ChecksApiSpecTest extends TestCase
         $nextUrl = "";
         $previousUrl = "";
 
-        $chk1 = self::$checksApi->create(self::$editableCheck);
-        $chk2 = self::$checksApi->create(self::$editableCheck2);
-        $listedChecks = self::$checksApi->list(2);
-        $this->assertGreaterThan(1, count($listedChecks->getData()));
-        $this->assertLessThanOrEqual(2, count($listedChecks->getData()));
-        $nextUrl = substr($listedChecks->getNextUrl(), strrpos($listedChecks->getNextUrl(), "after=") + 6);
-        $this->assertIsString($nextUrl);
-        array_push($this->idsForCleanup, $chk1->getId());
-        array_push($this->idsForCleanup, $chk2->getId());
+        try {
+            $chk1 = self::$checksApi->create(self::$editableCheck);
+            $chk2 = self::$checksApi->create(self::$editableCheck2);
+            $listedChecks = self::$checksApi->list(2);
+            $this->assertGreaterThan(1, count($listedChecks->getData()));
+            $this->assertLessThanOrEqual(2, count($listedChecks->getData()));
+            $nextUrl = substr($listedChecks->getNextUrl(), strrpos($listedChecks->getNextUrl(), "after=") + 6);
+            $this->assertIsString($nextUrl);
+            array_push($this->idsForCleanup, $chk1->getId());
+            array_push($this->idsForCleanup, $chk2->getId());
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+        }
 
         // response using nextUrl
         if ($nextUrl != "") {
-            $chk1 = self::$checksApi->create(self::$editableCheck);
-            $chk2 = self::$checksApi->create(self::$editableCheck2);
-            $listedChecksAfter = self::$checksApi->list(2, null, $nextUrl);
-            $this->assertGreaterThan(1, count($listedChecksAfter->getData()));
-            $this->assertLessThanOrEqual(2, count($listedChecksAfter->getData()));
-            $previousUrl = substr($listedChecksAfter->getPreviousUrl(), strrpos($listedChecksAfter->getPreviousUrl(), "before=") + 7);
-            $this->assertIsString($previousUrl);
-            array_push($this->idsForCleanup, $chk1->getId());
-            array_push($this->idsForCleanup, $chk2->getId());
+            try {
+                $chk1 = self::$checksApi->create(self::$editableCheck);
+                $chk2 = self::$checksApi->create(self::$editableCheck2);
+                $listedChecksAfter = self::$checksApi->list(2, null, $nextUrl);
+                $this->assertGreaterThan(1, count($listedChecksAfter->getData()));
+                $this->assertLessThanOrEqual(2, count($listedChecksAfter->getData()));
+                $previousUrl = substr($listedChecksAfter->getPreviousUrl(), strrpos($listedChecksAfter->getPreviousUrl(), "before=") + 7);
+                $this->assertIsString($previousUrl);
+                array_push($this->idsForCleanup, $chk1->getId());
+                array_push($this->idsForCleanup, $chk2->getId());
+            } catch (\Exception $e) {
+                throw new \Exception($e->getMessage());
+            }
         }
 
         // response using previousUrl
         if ($previousUrl != "") {
-            $chk1 = self::$checksApi->create(self::$editableCheck);
-            $chk2 = self::$checksApi->create(self::$editableCheck2);
-            $listedChecksBefore = self::$checksApi->list(2, $previousUrl);
-            $this->assertGreaterThan(1, count($listedChecksBefore->getData()));
-            $this->assertLessThanOrEqual(2, count($listedChecksBefore->getData()));
-            array_push($this->idsForCleanup, $chk1->getId());
-            array_push($this->idsForCleanup, $chk2->getId());
+            try {
+                $chk1 = self::$checksApi->create(self::$editableCheck);
+                $chk2 = self::$checksApi->create(self::$editableCheck2);
+                $listedChecksBefore = self::$checksApi->list(2, $previousUrl);
+                $this->assertGreaterThan(1, count($listedChecksBefore->getData()));
+                $this->assertLessThanOrEqual(2, count($listedChecksBefore->getData()));
+                array_push($this->idsForCleanup, $chk1->getId());
+                array_push($this->idsForCleanup, $chk2->getId());
+            } catch (\Exception $e) {
+                throw new \Exception($e->getMessage());
+            }
         }
     }
 
@@ -310,24 +334,32 @@ class ChecksApiSpecTest extends TestCase
      */
     public function testListWithParams($limit, $before, $after, $include, $date_created, $metadata, $scheduled, $send_date, $mail_type, $sort_by)
     {
-        // create checks to list
-        $chk1 = self::$checksApi->create(self::$editableCheck);
-        $chk2 = self::$checksApi->create(self::$editableCheck2);
-        $listedChecks = self::$checksApi->list($limit, $before, $after, $include, $date_created, $metadata, $scheduled, $send_date, $mail_type, $sort_by);
+        try {
+            // create checks to list
+            $chk1 = self::$checksApi->create(self::$editableCheck);
+            $chk2 = self::$checksApi->create(self::$editableCheck2);
+            $listedChecks = self::$checksApi->list($limit, $before, $after, $include, $date_created, $metadata, $scheduled, $send_date, $mail_type, $sort_by);
 
-        $this->assertGreaterThan(0, $listedChecks->getCount());
-        if ($include) $this->assertNotNull($listedChecks->getTotalCount());
+            $this->assertGreaterThan(0, $listedChecks->getCount());
+            if ($include) $this->assertNotNull($listedChecks->getTotalCount());
 
-        // cancel created checks
-        array_push($this->idsForCleanup, $chk1->getId());
-        array_push($this->idsForCleanup, $chk2->getId());
+            // cancel created checks
+            array_push($this->idsForCleanup, $chk1->getId());
+            array_push($this->idsForCleanup, $chk2->getId());
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+        }
     }
 
     public function testCancel200()
     {
-        $createdCheck = self::$checksApi->create(self::$editableCheck);
-        $deletedCheck = self::$checksApi->cancel($createdCheck->getId());
-        $this->assertEquals(true, $deletedCheck->getDeleted());
+        try {
+            $createdCheck = self::$checksApi->create(self::$editableCheck);
+            $deletedCheck = self::$checksApi->cancel($createdCheck->getId());
+            $this->assertEquals(true, $deletedCheck->getDeleted());
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+        }
     }
 
     public function testCancel401()

--- a/test/Integration/ChecksApiSpecTest.php
+++ b/test/Integration/ChecksApiSpecTest.php
@@ -290,12 +290,16 @@ class ChecksApiSpecTest extends TestCase
 
     public function provider()
     {
+        date_default_timezone_set('America/Los_Angeles');
+        $date_str = date("Y-m-d", strtotime("-1 months"));
+        $date_obj = (object) array("gt" => $date_str);
+
         return array(
-            // array(null, null, null, array("total_count"), null, null, null, null, null, null), // include
-            // array(null, null, null, null, array("gt" => (string)(date("c")), "lt" => (string)(date("c", time() + 86400))), null, null, null, null, null), // date_created
+            array(null, null, null, array("total_count"), null, null, null, null, null, null), // include
+            array(null, null, null, null, $date_obj, null, null, null, null, null), // date_created
             array(null, null, null, null, null, self::$metadata, null, null, null, null), // metadata
-            // array(null, null, null, null, null, null, TRUE, null, null, null), // scheduled
-            // array(null, null, null, null, null, null, null, array("gt" => (string)(date("c")), "lt" => (string)(date("c", time() + 86400))), null, null), // send_date
+            array(null, null, null, null, null, null, TRUE, null, null, null), // scheduled
+            array(null, null, null, null, null, null, null, $date_obj, null, null), // send_date
             array(null, null, null, null, null, null, null, null, MailType::FIRST_CLASS->value, null), // mail_type
             array(null, null, null, null, null, null, null, null, null, new SortBy5(array("date_created" => "asc"))) // sort_by
         );

--- a/test/Integration/IntlAutocompletionsApiSpecTest.php
+++ b/test/Integration/IntlAutocompletionsApiSpecTest.php
@@ -72,8 +72,8 @@ class IntlAutocompletionsApiSpecTest extends TestCase
         try {
             $intlAutocompletionApi = new IntlAutocompletionsApi(self::$config);
             $this->assertEquals(gettype($intlAutocompletionApi), 'object');
-        } catch (Exception $instantiationError) {
-            echo 'Caught exception: ',  $instantiationError->getMessage(), "\n";
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
         }
     }
 
@@ -83,8 +83,8 @@ class IntlAutocompletionsApiSpecTest extends TestCase
             $intlAutocompletionObject = self::$intlAutocompletionApi->autocomplete(self::$autocompletionWritable);
             // $this->assertMatchesRegularExpression('/intl_auto_/', $intlAutocompletionObject->getId()); // will re-add once bug in API is addressed:
             $this->assertGreaterThan(0, count($intlAutocompletionObject->getSuggestions()));
-        } catch (Exception $createError) {
-            echo 'Caught exception: ',  $createError->getMessage(), "\n";
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
         }
     }
 
@@ -102,26 +102,21 @@ class IntlAutocompletionsApiSpecTest extends TestCase
 
             $intlAutocompletionObject = $autocompletionApiError->autocomplete($testAutocompletion);
             $this->assertEquals("TEST KEYS DO NOT AUTOCOMPLETE INTL ADDRESSES", $intlAutocompletionObject->getSuggestions()[0]->getPrimaryLine());
-
-        } catch (Exception $createError) {
-            echo 'Caught exception: ',  $createError->getMessage(), "\n";
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
         }
     }
 
     public function testIntlAutocompletionError()
     {
-        try {
-            // error autocompletion object
-            $errorAutocompletion = new IntlAutocompletionsWritable();
-            $errorAutocompletion->setCity("LONDON");
-            $errorAutocompletion->setZipCode("EC3N 4DR");
-            $errorAutocompletion->setCountry("GB");
+        // error autocompletion object
+        $errorAutocompletion = new IntlAutocompletionsWritable();
+        $errorAutocompletion->setCity("LONDON");
+        $errorAutocompletion->setZipCode("EC3N 4DR");
+        $errorAutocompletion->setCountry("GB");
 
-            $this->expectException(ApiException::class);
-            $this->expectExceptionMessageMatches("/address_prefix is required/");
-            $errorResponse = self::$intlAutocompletionApi->autocomplete($errorAutocompletion);
-        } catch (Exception $createError) {
-            echo 'Caught exception: ',  $createError->getMessage(), "\n";
-        }
+        $this->expectException(ApiException::class);
+        $this->expectExceptionMessageMatches("/address_prefix is required/");
+        $errorResponse = self::$intlAutocompletionApi->autocomplete($errorAutocompletion);
     }
 }

--- a/test/Integration/IntlVerificationsApiSpecTest.php
+++ b/test/Integration/IntlVerificationsApiSpecTest.php
@@ -104,62 +104,61 @@ class IntlVerificationsApiSpecTest extends TestCase
         try {
             $intlvApi200 = new IntlVerificationsApi(self::$config);
             $this->assertEquals(gettype($intlvApi200), 'object');
-        } catch (Exception $instantiationError) {
-            echo 'Caught exception: ',  $instantiationError->getMessage(), "\n";
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
         }
     }
 
-    public function testSingleUsVerificationDeliverable()
+    public function testSingleIntlVerificationDeliverable()
     {
         try {
             $intlVerificationObject = self::$intlvApi200->verifySingle(self::$validAddress1);
             $this->assertMatchesRegularExpression('/intl_ver_/', $intlVerificationObject->getId());
             $this->assertEquals('deliverable', $intlVerificationObject->getDeliverability());
-        } catch (Exception $createError) {
-            echo 'Caught exception: ',  $createError->getMessage(), "\n";
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
         }
     }
 
-    public function testSingleUsVerificationUndeliverable()
+    public function testSingleIntlVerificationUndeliverable()
     {
         try {
             $intlVerificationObject = self::$intlvApi200->verifySingle(self::$undeliverableAddress);
             $this->assertMatchesRegularExpression('/intl_ver_/', $intlVerificationObject->getId());
             $this->assertEquals('undeliverable', $intlVerificationObject->getDeliverability());
-
-        } catch (Exception $createError) {
-            echo 'Caught exception: ',  $createError->getMessage(), "\n";
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
         }
     }
 
-    public function testBulkUsVerificationValid()
+    public function testBulkIntlVerificationValid()
     {
         try {
             $intlVerificationObject = self::$intlvApi200->verifyBulk(self::$multipleAddressList);
             $this->assertGreaterThan(1, count($intlVerificationObject->getAddresses()));
             $this->assertEquals('deliverable', $intlVerificationObject->getAddresses()[0]->getDeliverability());
             $this->assertEquals('undeliverable', $intlVerificationObject->getAddresses()[1]->getDeliverability());
-        } catch (Exception $createError) {
-            echo 'Caught exception: ',  $createError->getMessage(), "\n";
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
         }
     }
 
-    public function testBulkUsVerificationError()
+    public function testBulkIntlVerificationError()
     {
         try {
             $mc1 = new MultipleComponentsIntl();
             $mc1->setPrimaryLine("10 DOWNING ST");
             $mc1->setCity("LONDON");
             $mc1->setPostalCode("SW1A 2AA");
-            $mc1->setCountry("GB");    
-    
+            $mc1->setCountry("GB");
+
             // second entry has nonexistent country, should error
             $mc2 = new MultipleComponentsIntl();
             $mc2->setPrimaryLine("35 TOWER HILL");
             $mc2->setCity("LONDON");
             $mc2->setPostalCode("EC3N 4DR");
             $mc2->setCountry("ZZ");
-    
+
             // multiple components list for bulk verification test
             $errorAddressList = new IntlVerificationsPayload();
             $errorAddressList->setAddresses([$mc1, $mc2]);
@@ -168,8 +167,8 @@ class IntlVerificationsApiSpecTest extends TestCase
 
             $this->assertMatchesRegularExpression('/country must be one of/', $errorVerificationObject->getAddresses()[1]->getError()->getError()->getMessage());
             $this->assertEquals(1, $errorVerificationObject->getErrors());
-        } catch (Exception $createError) {
-            echo 'Caught exception: ',  $createError->getMessage(), "\n";
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
         }
     }
 }

--- a/test/Integration/LettersApiSpecTest.php
+++ b/test/Integration/LettersApiSpecTest.php
@@ -290,13 +290,17 @@ class LettersApiSpecTest extends TestCase
 
     public function provider()
     {
+        date_default_timezone_set('America/Los_Angeles');
+        $date_str = date("Y-m-d", strtotime("-1 months"));
+        $date_obj = (object) array("gt" => $date_str);
+
         return array(
-            // array(null, null, null, array("total_count"), null, null, null, null, null, null, null), // include
-            // array(null, null, null, null, array("gt" => (string)(date("c")), "lt" => (string)(date("c", time() + 86400))), null, null, null, null, null, null), // date_created
+            array(null, null, null, array("total_count"), null, null, null, null, null, null, null), // include
+            array(null, null, null, null, $date_obj, null, null, null, null, null, null), // date_created
             array(null, null, null, null, null, self::$metadata, null, null, null, null, null), // metadata
-            // array(null, null, null, null, null, null, TRUE, null, null, null, null), // color
-            // array(null, null, null, null, null, null, null, TRUE, null, null, null), // scheduled
-            // array(null, null, null, null, null, null, null, null, array("gt" => (string)(date("c")), "lt" => (string)(date("c", time() + 86400))), null, null), // send_date
+            array(null, null, null, null, null, null, TRUE, null, null, null, null), // color
+            array(null, null, null, null, null, null, null, TRUE, null, null, null), // scheduled
+            array(null, null, null, null, null, null, null, null, $date_obj, null, null), // send_date
             array(null, null, null, null, null, null, null, null, null, MailType::FIRST_CLASS->value, null), // mail_type
             array(null, null, null, null, null, null, null, null, null, null, new SortBy5(array("date_created" => "asc"))) // sort_by
         );

--- a/test/Integration/LettersApiSpecTest.php
+++ b/test/Integration/LettersApiSpecTest.php
@@ -173,29 +173,45 @@ class LettersApiSpecTest extends TestCase
     }
 
     public function testLettersApiInstantiation200() {
-        $lettersApi200 = new LettersApi(self::$config);
-        $this->assertEquals(gettype($lettersApi200), 'object');
+        try {
+            $lettersApi200 = new LettersApi(self::$config);
+            $this->assertEquals(gettype($lettersApi200), 'object');
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+        }
     }
 
     public function testCreateRegular200()
     {
-        $createdLetter = self::$letterApi->create(self::$regularLetter);
-        $this->assertMatchesRegularExpression('/ltr_/', $createdLetter->getId());
-        array_push($this->idsForCleanup, $createdLetter->getId());
+        try {
+            $createdLetter = self::$letterApi->create(self::$regularLetter);
+            $this->assertMatchesRegularExpression('/ltr_/', $createdLetter->getId());
+            array_push($this->idsForCleanup, $createdLetter->getId());
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+        }
     }
 
     public function testCreateCertified200()
     {
-        $createdLetter = self::$letterApi->create(self::$certifiedLetter);
-        $this->assertMatchesRegularExpression('/ltr_/', $createdLetter->getId());
-        array_push($this->idsForCleanup, $createdLetter->getId());
+        try {
+            $createdLetter = self::$letterApi->create(self::$certifiedLetter);
+            $this->assertMatchesRegularExpression('/ltr_/', $createdLetter->getId());
+            array_push($this->idsForCleanup, $createdLetter->getId());
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+        }
     }
 
     public function testCreateRegistered200()
     {
-        $createdLetter = self::$letterApi->create(self::$registeredLetter);
-        $this->assertMatchesRegularExpression('/ltr_/', $createdLetter->getId());
-        array_push($this->idsForCleanup, $createdLetter->getId());
+        try {
+            $createdLetter = self::$letterApi->create(self::$registeredLetter);
+            $this->assertMatchesRegularExpression('/ltr_/', $createdLetter->getId());
+            array_push($this->idsForCleanup, $createdLetter->getId());
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+        }
     }
 
     // does not include required field in request
@@ -219,10 +235,14 @@ class LettersApiSpecTest extends TestCase
 
     public function testGet200()
     {
-        $createdLetter = self::$letterApi->create(self::$regularLetter);
-        $retrievedLetter = self::$letterApi->get($createdLetter->getId());
-        $this->assertEquals($createdLetter->getTo(), $retrievedLetter->getTo());
-        array_push($this->idsForCleanup, $createdLetter->getId());
+        try {
+            $createdLetter = self::$letterApi->create(self::$regularLetter);
+            $retrievedLetter = self::$letterApi->get($createdLetter->getId());
+            $this->assertEquals($createdLetter->getTo(), $retrievedLetter->getTo());
+            array_push($this->idsForCleanup, $createdLetter->getId());
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+        }
     }
 
     public function testGet0()
@@ -253,38 +273,50 @@ class LettersApiSpecTest extends TestCase
     {
         $nextUrl = "";
         $previousUrl = "";
-        $ltr1 = self::$letterApi->create(self::$regularLetter);
-        $ltr2 = self::$letterApi->create(self::$registeredLetter);
-        $listedLetters = self::$letterApi->list(2);
-        $this->assertGreaterThan(1, count($listedLetters->getData()));
-        $this->assertLessThanOrEqual(2, count($listedLetters->getData()));
-        $nextUrl = substr($listedLetters->getNextUrl(), strrpos($listedLetters->getNextUrl(), "after=") + 6);
-        $this->assertIsString($nextUrl);
-        array_push($this->idsForCleanup, $ltr1->getId());
-        array_push($this->idsForCleanup, $ltr2->getId());
+        try {
+            $ltr1 = self::$letterApi->create(self::$regularLetter);
+            $ltr2 = self::$letterApi->create(self::$registeredLetter);
+            $listedLetters = self::$letterApi->list(2);
+            $this->assertGreaterThan(1, count($listedLetters->getData()));
+            $this->assertLessThanOrEqual(2, count($listedLetters->getData()));
+            $nextUrl = substr($listedLetters->getNextUrl(), strrpos($listedLetters->getNextUrl(), "after=") + 6);
+            $this->assertIsString($nextUrl);
+            array_push($this->idsForCleanup, $ltr1->getId());
+            array_push($this->idsForCleanup, $ltr2->getId());
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+        }
 
         // response using nextUrl
         if ($nextUrl != "") {
-            $ltr1 = self::$letterApi->create(self::$regularLetter);
-            $ltr2 = self::$letterApi->create(self::$registeredLetter);
-            $listedLettersAfter = self::$letterApi->list(2, null, $nextUrl);
-            $this->assertGreaterThan(1, count($listedLettersAfter->getData()));
-            $this->assertLessThanOrEqual(2, count($listedLettersAfter->getData()));
-            $previousUrl = substr($listedLettersAfter->getPreviousUrl(), strrpos($listedLettersAfter->getPreviousUrl(), "before=") + 7);
-            $this->assertIsString($previousUrl);
-            array_push($this->idsForCleanup, $ltr1->getId());
-            array_push($this->idsForCleanup, $ltr2->getId());
+            try {
+                $ltr1 = self::$letterApi->create(self::$regularLetter);
+                $ltr2 = self::$letterApi->create(self::$registeredLetter);
+                $listedLettersAfter = self::$letterApi->list(2, null, $nextUrl);
+                $this->assertGreaterThan(1, count($listedLettersAfter->getData()));
+                $this->assertLessThanOrEqual(2, count($listedLettersAfter->getData()));
+                $previousUrl = substr($listedLettersAfter->getPreviousUrl(), strrpos($listedLettersAfter->getPreviousUrl(), "before=") + 7);
+                $this->assertIsString($previousUrl);
+                array_push($this->idsForCleanup, $ltr1->getId());
+                array_push($this->idsForCleanup, $ltr2->getId());
+            } catch (\Exception $e) {
+                throw new \Exception($e->getMessage());
+            }
         }
 
         // response using previousUrl
         if ($previousUrl != "") {
-            $ltr1 = self::$letterApi->create(self::$regularLetter);
-            $ltr2 = self::$letterApi->create(self::$registeredLetter);
-            $listedLettersBefore = self::$letterApi->list(2, $previousUrl);
-            $this->assertGreaterThan(1, count($listedLettersBefore->getData()));
-            $this->assertLessThanOrEqual(2, count($listedLettersBefore->getData()));
-            array_push($this->idsForCleanup, $ltr1->getId());
-            array_push($this->idsForCleanup, $ltr2->getId());
+            try {
+                $ltr1 = self::$letterApi->create(self::$regularLetter);
+                $ltr2 = self::$letterApi->create(self::$registeredLetter);
+                $listedLettersBefore = self::$letterApi->list(2, $previousUrl);
+                $this->assertGreaterThan(1, count($listedLettersBefore->getData()));
+                $this->assertLessThanOrEqual(2, count($listedLettersBefore->getData()));
+                array_push($this->idsForCleanup, $ltr1->getId());
+                array_push($this->idsForCleanup, $ltr2->getId());
+            } catch (\Exception $e) {
+                throw new \Exception($e->getMessage());
+            }
         }
     }
 
@@ -311,24 +343,32 @@ class LettersApiSpecTest extends TestCase
      */
     public function testListWithParams($limit, $before, $after, $include, $date_created, $metadata, $color, $scheduled, $send_date, $mail_type, $sort_by)
     {
-        // create letters to list
-        $ltr1 = self::$letterApi->create(self::$regularLetter);
-        $ltr2 = self::$letterApi->create(self::$registeredLetter);
-        $listedLetters = self::$letterApi->list($limit, $before, $after, $include, $date_created, $metadata, $color, $scheduled, $send_date, $mail_type, $sort_by);
+        try {
+            // create letters to list
+            $ltr1 = self::$letterApi->create(self::$regularLetter);
+            $ltr2 = self::$letterApi->create(self::$registeredLetter);
+            $listedLetters = self::$letterApi->list($limit, $before, $after, $include, $date_created, $metadata, $color, $scheduled, $send_date, $mail_type, $sort_by);
 
-        $this->assertGreaterThan(0, $listedLetters->getCount());
-        if ($include) $this->assertNotNull($listedLetters->getTotalCount());
+            $this->assertGreaterThan(0, $listedLetters->getCount());
+            if ($include) $this->assertNotNull($listedLetters->getTotalCount());
 
-        // cancel created letters
-        array_push($this->idsForCleanup, $ltr1->getId());
-        array_push($this->idsForCleanup, $ltr2->getId());
+            // cancel created letters
+            array_push($this->idsForCleanup, $ltr1->getId());
+            array_push($this->idsForCleanup, $ltr2->getId());
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+        }
     }
 
     public function testCancel200()
     {
-        $createdLetter = self::$letterApi->create(self::$regularLetter);
-        $deletedLetter = self::$letterApi->cancel($createdLetter->getId());
-        $this->assertEquals(true, $deletedLetter->getDeleted());
+        try {
+            $createdLetter = self::$letterApi->create(self::$regularLetter);
+            $deletedLetter = self::$letterApi->cancel($createdLetter->getId());
+            $this->assertEquals(true, $deletedLetter->getDeleted());
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+        }
     }
 
     public function testCancel401()

--- a/test/Integration/PostcardsApiSpecTest.php
+++ b/test/Integration/PostcardsApiSpecTest.php
@@ -181,15 +181,23 @@ class PostcardsApiSpecTest extends TestCase
     // include static cleanup for all the addresses?
 
     public function testPostcardsApiInstantiation200() {
-        $postcardsApi200 = new PostcardsApi(self::$config);
-        $this->assertEquals(gettype($postcardsApi200), 'object');
+        try {
+            $postcardsApi200 = new PostcardsApi(self::$config);
+            $this->assertEquals(gettype($postcardsApi200), 'object');
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+        }
     }
 
     public function testCreate200()
     {
-        $createdPostcard = self::$postcardsApi->create(self::$editablePostcard);
-        $this->assertMatchesRegularExpression('/psc_/', $createdPostcard->getId());
-        array_push($this->idsForCleanup, $createdPostcard->getId());
+        try {
+            $createdPostcard = self::$postcardsApi->create(self::$editablePostcard);
+            $this->assertMatchesRegularExpression('/psc_/', $createdPostcard->getId());
+            array_push($this->idsForCleanup, $createdPostcard->getId());
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+        }
     }
 
     // does not include required field in request
@@ -231,10 +239,14 @@ class PostcardsApiSpecTest extends TestCase
 
     public function testGet200()
     {
-        $createdPostcard = self::$postcardsApi->create(self::$editablePostcard);
-        $retrievedPostcard = self::$postcardsApi->get($createdPostcard->getId());
-        $this->assertEquals($createdPostcard->getTo(), $retrievedPostcard->getTo());
-        array_push($this->idsForCleanup, $createdPostcard->getId());
+        try {
+            $createdPostcard = self::$postcardsApi->create(self::$editablePostcard);
+            $retrievedPostcard = self::$postcardsApi->get($createdPostcard->getId());
+            $this->assertEquals($createdPostcard->getTo(), $retrievedPostcard->getTo());
+            array_push($this->idsForCleanup, $createdPostcard->getId());
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+        }
     }
 
     public function testGet0()
@@ -265,38 +277,50 @@ class PostcardsApiSpecTest extends TestCase
     {
         $nextUrl = "";
         $previousUrl = "";
-        $psc1 = self::$postcardsApi->create(self::$editablePostcard);
-        $psc2 = self::$postcardsApi->create(self::$editablePostcard2);
-        $listedPostcards = self::$postcardsApi->list(2);
-        $this->assertGreaterThan(1, count($listedPostcards->getData()));
-        $this->assertLessThanOrEqual(2, count($listedPostcards->getData()));
-        $nextUrl = substr($listedPostcards->getNextUrl(), strrpos($listedPostcards->getNextUrl(), "after=") + 6);
-        $this->assertIsString($nextUrl);
-        array_push($this->idsForCleanup, $psc1->getId());
-        array_push($this->idsForCleanup, $psc2->getId());
+        try {
+            $psc1 = self::$postcardsApi->create(self::$editablePostcard);
+            $psc2 = self::$postcardsApi->create(self::$editablePostcard2);
+            $listedPostcards = self::$postcardsApi->list(2);
+            $this->assertGreaterThan(1, count($listedPostcards->getData()));
+            $this->assertLessThanOrEqual(2, count($listedPostcards->getData()));
+            $nextUrl = substr($listedPostcards->getNextUrl(), strrpos($listedPostcards->getNextUrl(), "after=") + 6);
+            $this->assertIsString($nextUrl);
+            array_push($this->idsForCleanup, $psc1->getId());
+            array_push($this->idsForCleanup, $psc2->getId());
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+        }
 
         // response using nextUrl
         if ($nextUrl != "") {
-            $psc1 = self::$postcardsApi->create(self::$editablePostcard);
-            $psc2 = self::$postcardsApi->create(self::$editablePostcard2);
-            $listedPostcardsAfter = self::$postcardsApi->list(2, null, $nextUrl);
-            $this->assertGreaterThan(1, count($listedPostcardsAfter->getData()));
-            $this->assertLessThanOrEqual(2, count($listedPostcardsAfter->getData()));
-            $previousUrl = substr($listedPostcardsAfter->getPreviousUrl(), strrpos($listedPostcardsAfter->getPreviousUrl(), "before=") + 7);
-            $this->assertIsString($previousUrl);
-            array_push($this->idsForCleanup, $psc1->getId());
-            array_push($this->idsForCleanup, $psc2->getId());
+            try {
+                $psc1 = self::$postcardsApi->create(self::$editablePostcard);
+                $psc2 = self::$postcardsApi->create(self::$editablePostcard2);
+                $listedPostcardsAfter = self::$postcardsApi->list(2, null, $nextUrl);
+                $this->assertGreaterThan(1, count($listedPostcardsAfter->getData()));
+                $this->assertLessThanOrEqual(2, count($listedPostcardsAfter->getData()));
+                $previousUrl = substr($listedPostcardsAfter->getPreviousUrl(), strrpos($listedPostcardsAfter->getPreviousUrl(), "before=") + 7);
+                $this->assertIsString($previousUrl);
+                array_push($this->idsForCleanup, $psc1->getId());
+                array_push($this->idsForCleanup, $psc2->getId());
+            } catch (\Exception $e) {
+                throw new \Exception($e->getMessage());
+            }
         }
 
         // response using previousUrl
         if ($previousUrl != "") {
-            $psc1 = self::$postcardsApi->create(self::$editablePostcard);
-            $psc2 = self::$postcardsApi->create(self::$editablePostcard2);
-            $listedPostcardsBefore = self::$postcardsApi->list(2, $previousUrl);
-            $this->assertGreaterThan(1, count($listedPostcardsBefore->getData()));
-            $this->assertLessThanOrEqual(2, count($listedPostcardsBefore->getData()));
-            array_push($this->idsForCleanup, $psc1->getId());
-            array_push($this->idsForCleanup, $psc2->getId());
+            try {
+                $psc1 = self::$postcardsApi->create(self::$editablePostcard);
+                $psc2 = self::$postcardsApi->create(self::$editablePostcard2);
+                $listedPostcardsBefore = self::$postcardsApi->list(2, $previousUrl);
+                $this->assertGreaterThan(1, count($listedPostcardsBefore->getData()));
+                $this->assertLessThanOrEqual(2, count($listedPostcardsBefore->getData()));
+                array_push($this->idsForCleanup, $psc1->getId());
+                array_push($this->idsForCleanup, $psc2->getId());
+            } catch (\Exception $e) {
+                throw new \Exception($e->getMessage());
+            }
         }
     }
 
@@ -323,24 +347,32 @@ class PostcardsApiSpecTest extends TestCase
      */
     public function testListWithParams($limit, $before, $after, $include, $date_created, $metadata, $size, $scheduled, $send_date, $mail_type, $sort_by)
     {
-        // create postcards to list
-        $psc1 = self::$postcardsApi->create(self::$editablePostcard);
-        $psc2 = self::$postcardsApi->create(self::$editablePostcard2);
+        try {
+            // create postcards to list
+            $psc1 = self::$postcardsApi->create(self::$editablePostcard);
+            $psc2 = self::$postcardsApi->create(self::$editablePostcard2);
 
-        // cancel created postcards
-        array_push($this->idsForCleanup, $psc1->getId());
-        array_push($this->idsForCleanup, $psc2->getId());
-        $listedPostcards = self::$postcardsApi->list($limit, $before, $after, $include, $date_created, $metadata, $size, $scheduled, $send_date, $mail_type, $sort_by);
+            // cancel created postcards
+            array_push($this->idsForCleanup, $psc1->getId());
+            array_push($this->idsForCleanup, $psc2->getId());
+            $listedPostcards = self::$postcardsApi->list($limit, $before, $after, $include, $date_created, $metadata, $size, $scheduled, $send_date, $mail_type, $sort_by);
 
-        $this->assertGreaterThan(0, $listedPostcards->getCount());
-        if ($include) $this->assertNotNull($listedPostcards->getTotalCount());
+            $this->assertGreaterThan(0, $listedPostcards->getCount());
+            if ($include) $this->assertNotNull($listedPostcards->getTotalCount());
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+        }
     }
 
     public function testCancel200()
     {
-        $createdPostcard = self::$postcardsApi->create(self::$editablePostcard);
-        $deletedPostcard = self::$postcardsApi->cancel($createdPostcard->getId());
-        $this->assertEquals(true, $deletedPostcard->getDeleted());
+        try {
+            $createdPostcard = self::$postcardsApi->create(self::$editablePostcard);
+            $deletedPostcard = self::$postcardsApi->cancel($createdPostcard->getId());
+            $this->assertEquals(true, $deletedPostcard->getDeleted());
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+        }
     }
 
     public function testCancel401()

--- a/test/Integration/ReverseGeocodeLookupsApiSpecTest.php
+++ b/test/Integration/ReverseGeocodeLookupsApiSpecTest.php
@@ -69,29 +69,43 @@ class ReverseGeocodeLookupsApiSpecTest extends TestCase
     }
 
     public function testReverseGeocodeLookupsApiInstantiation200() {
-        try {
-            $reverseGeocodeApi = new ReverseGeocodeLookupsApi(self::$config);
-            $this->assertEquals(gettype($reverseGeocodeApi), 'object');
-        } catch (Exception $instantiationError) {
-            echo 'Caught exception: ',  $instantiationError->getMessage(), "\n";
-        }
+        $reverseGeocodeApi = new ReverseGeocodeLookupsApi(self::$config);
+        $this->assertEquals(gettype($reverseGeocodeApi), 'object');
     }
 
     public function testLookup()
     {
-        try {
-            $location = new Location();
-            $location->setLatitude(37.777456);
-            $location->setLongitude(-122.393039);
-            $reverseGeocodeObject = self::$reverseGeocodeApi->lookup($location, self::$size);
-            $this->assertMatchesRegularExpression('/us_reverse_geocode_/', $reverseGeocodeObject->getId());
-            $this->assertGreaterThanOrEqual(1, count($reverseGeocodeObject->getAddresses()));
-        } catch (Exception $createError) {
-            echo 'Caught exception: ',  $createError->getMessage(), "\n";
-        }
+        $location = new Location();
+        $location->setLatitude(37.777456);
+        $location->setLongitude(-122.393039);
+        $reverseGeocodeObject = self::$reverseGeocodeApi->lookup($location, self::$size);
+        $this->assertMatchesRegularExpression('/us_reverse_geocode_/', $reverseGeocodeObject->getId());
+        $this->assertGreaterThanOrEqual(1, count($reverseGeocodeObject->getAddresses()));
     }
 
-    public function testLookupError()
+    public function testLookup0()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches("/Missing the required parameter/");
+        $reverseGeocodeObject = self::$reverseGeocodeApi->lookup(null);
+    }
+
+    public function testLookup401()
+    {
+        $location = new Location();
+        $location->setLatitude(37.777456);
+        $location->setLongitude(-122.393039);
+
+        $wrongConfig = new Configuration();
+        $wrongConfig->setApiKey('basic', 'BAD KEY');
+        $invalidApi = new ReverseGeocodeLookupsApi($wrongConfig);
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessageMatches("/Your API key is not valid/");
+        $reverseGeocodeObject = $invalidApi->lookup($location, self::$size);
+    }
+
+    public function testLookup422()
     {
         $location = new Location();
         $location->setLongitude(-122.393039);

--- a/test/Integration/ReverseGeocodeLookupsApiSpecTest.php
+++ b/test/Integration/ReverseGeocodeLookupsApiSpecTest.php
@@ -69,18 +69,26 @@ class ReverseGeocodeLookupsApiSpecTest extends TestCase
     }
 
     public function testReverseGeocodeLookupsApiInstantiation200() {
-        $reverseGeocodeApi = new ReverseGeocodeLookupsApi(self::$config);
-        $this->assertEquals(gettype($reverseGeocodeApi), 'object');
+        try {
+            $reverseGeocodeApi = new ReverseGeocodeLookupsApi(self::$config);
+            $this->assertEquals(gettype($reverseGeocodeApi), 'object');
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+        }
     }
 
     public function testLookup()
     {
-        $location = new Location();
-        $location->setLatitude(37.777456);
-        $location->setLongitude(-122.393039);
-        $reverseGeocodeObject = self::$reverseGeocodeApi->lookup($location, self::$size);
-        $this->assertMatchesRegularExpression('/us_reverse_geocode_/', $reverseGeocodeObject->getId());
-        $this->assertGreaterThanOrEqual(1, count($reverseGeocodeObject->getAddresses()));
+        try {
+            $location = new Location();
+            $location->setLatitude(37.777456);
+            $location->setLongitude(-122.393039);
+            $reverseGeocodeObject = self::$reverseGeocodeApi->lookup($location, self::$size);
+            $this->assertMatchesRegularExpression('/us_reverse_geocode_/', $reverseGeocodeObject->getId());
+            $this->assertGreaterThanOrEqual(1, count($reverseGeocodeObject->getAddresses()));
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+        }
     }
 
     public function testLookup0()

--- a/test/Integration/SelfMailersApiSpecTest.php
+++ b/test/Integration/SelfMailersApiSpecTest.php
@@ -26,296 +26,294 @@
  * Please update the test case below to test the endpoint.
  */
 
-// TODO: commented this whole test file since selfMailer objects aren't deserialized properly
+namespace OpenAPI\Client\Test\Api;
 
-// namespace OpenAPI\Client\Test\Api;
+use \OpenAPI\Client\Configuration;
+use \OpenAPI\Client\ApiException;
+use PHPUnit\Framework\TestCase;
+use \OpenAPI\Client\Model\SelfMailerEditable;
+use \OpenAPI\Client\Api\SelfMailersApi;
+use \OpenAPI\Client\Model\AddressEditable;
+use \OpenAPI\Client\Api\AddressesApi;
+use \OpenAPI\Client\Model\SelfMailerSize;
+use \OpenAPI\Client\Model\MailType;
+use \OpenAPI\Client\Model\SortBy5;
+/**
+ * AddressesApiTest Class Doc Comment
+ *
+ * @category Class
+ * @package  OpenAPI\Client
+ * @author   OpenAPI Generator team
+ * @link     https://openapi-generator.tech
+ */
 
-// use \OpenAPI\Client\Configuration;
-// use \OpenAPI\Client\ApiException;
-// use PHPUnit\Framework\TestCase;
-// use \OpenAPI\Client\Model\SelfMailerEditable;
-// use \OpenAPI\Client\Api\SelfMailersApi;
-// use \OpenAPI\Client\Model\AddressEditable;
-// use \OpenAPI\Client\Api\AddressesApi;
-// use \OpenAPI\Client\Model\SelfMailerSize;
-// use \OpenAPI\Client\Model\MailType;
-// use \OpenAPI\Client\Model\SortBy5;
-// /**
-//  * AddressesApiTest Class Doc Comment
-//  *
-//  * @category Class
-//  * @package  OpenAPI\Client
-//  * @author   OpenAPI Generator team
-//  * @link     https://openapi-generator.tech
-//  */
+class SelfMailersApiSpecTest extends TestCase
+{
+    /**
+     * Setup before running any test cases
+     */
+    private static $config;
+    private static $addressApi;
+    private static $selfMailersApi;
+    private static $invalidSelfMailerApi;
+    private static $editableSelfMailer;
+    private static $editableSelfMailer2;
+    private static $errorSelfMailer;
+    private static $metadata;
 
-// class SelfMailersApiSpecTest extends TestCase
-// {
-//     /**
-//      * Setup before running any test cases
-//      */
-//     private static $config;
-//     private static $addressApi;
-//     private static $selfMailersApi;
-//     private static $invalidSelfMailerApi;
-//     private static $editableSelfMailer;
-//     private static $editableSelfMailer2;
-//     private static $errorSelfMailer;
-//     private static $metadata;
+    // for teardown post-testing
+    private $idsForCleanup = [];
+    private static $toAddress;
+    private static $fromAddress;
+    private static $toAddress2;
+    private static $fromAddress2;
 
-//     // for teardown post-testing
-//     private $idsForCleanup = [];
-//     private static $toAddress;
-//     private static $fromAddress;
-//     private static $toAddress2;
-//     private static $fromAddress2;
+    // set up constant fixtures
+    public static function setUpBeforeClass(): void
+    {
+        // create instance of AddressesApi & addresses to use for other tests
+        self::$config = new Configuration();
+        self::$config->setApiKey('basic', getenv('LOB_API_TEST_KEY'));
+        self::$addressApi = new AddressesApi(self::$config);
 
-//     // set up constant fixtures
-//     public static function setUpBeforeClass(): void
-//     {
-//         // create instance of AddressesApi & addresses to use for other tests
-//         self::$config = new Configuration();
-//         self::$config->setApiKey('basic', getenv('LOB_API_TEST_KEY'));
-//         self::$addressApi = new AddressesApi(self::$config);
+        $address1 = new AddressEditable();
+        $address1->setName("THING T. THING");
+        $address1->setAddressLine1("1313 CEMETERY LN");
+        $address1->setAddressCity("WESTFIELD");
+        $address1->setAddressState("NJ");
+        $address1->setAddressZip("07000");
 
-//         $address1 = new AddressEditable();
-//         $address1->setName("THING T. THING");
-//         $address1->setAddressLine1("1313 CEMETERY LN");
-//         $address1->setAddressCity("WESTFIELD");
-//         $address1->setAddressState("NJ");
-//         $address1->setAddressZip("07000");
+        $address2 = new AddressEditable();
+        $address2->setName("FESTER");
+        $address2->setAddressLine1("001 CEMETERY LN");
+        $address2->setAddressLine2("SUITE 666");
+        $address2->setAddressCity("WESTFIELD");
+        $address2->setAddressState("NJ");
+        $address2->setAddressZip("07000");
 
-//         $address2 = new AddressEditable();
-//         $address2->setName("FESTER");
-//         $address2->setAddressLine1("001 CEMETERY LN");
-//         $address2->setAddressLine2("SUITE 666");
-//         $address2->setAddressCity("WESTFIELD");
-//         $address2->setAddressState("NJ");
-//         $address2->setAddressZip("07000");
+        self::$toAddress = self::$addressApi->create($address1);
+        self::$fromAddress = self::$addressApi->create($address2);
 
-//         self::$toAddress = self::$addressApi->create($address1);
-//         self::$fromAddress = self::$addressApi->create($address2);
+        $address3 = new AddressEditable();
+        $address3->setName("MORTICIA ADDAMS");
+        $address3->setAddressLine1("1212 CEMETERY LN");
+        $address3->setAddressCity("WESTFIELD");
+        $address3->setAddressState("NJ");
+        $address3->setAddressZip("07000");
 
-//         $address3 = new AddressEditable();
-//         $address3->setName("MORTICIA ADDAMS");
-//         $address3->setAddressLine1("1212 CEMETERY LN");
-//         $address3->setAddressCity("WESTFIELD");
-//         $address3->setAddressState("NJ");
-//         $address3->setAddressZip("07000");
+        $address4 = new AddressEditable();
+        $address4->setName("COUSIN ITT");
+        $address4->setAddressLine1("1515 CEMETERY LN");
+        $address4->setAddressLine2("FLOOR 0");
+        $address4->setAddressCity("WESTFIELD");
+        $address4->setAddressState("NJ");
+        $address4->setAddressZip("07000");
 
-//         $address4 = new AddressEditable();
-//         $address4->setName("COUSIN ITT");
-//         $address4->setAddressLine1("1515 CEMETERY LN");
-//         $address4->setAddressLine2("FLOOR 0");
-//         $address4->setAddressCity("WESTFIELD");
-//         $address4->setAddressState("NJ");
-//         $address4->setAddressZip("07000");
+        self::$toAddress2 = self::$addressApi->create($address3);
+        self::$fromAddress2 = self::$addressApi->create($address4);
 
-//         self::$toAddress2 = self::$addressApi->create($address3);
-//         self::$fromAddress2 = self::$addressApi->create($address4);
+        // create new instance of SelfMailersApi to use in other tests
+        self::$selfMailersApi = new SelfMailersApi(self::$config);
 
-//         // create new instance of SelfMailersApi to use in other tests
-//         self::$selfMailersApi = new SelfMailersApi(self::$config);
+        $wrongConfig = new Configuration();
+        $wrongConfig->setApiKey('basic', 'BAD KEY');
+        self::$invalidSelfMailerApi = new SelfMailersApi($wrongConfig);
 
-//         $wrongConfig = new Configuration();
-//         $wrongConfig->setApiKey('basic', 'BAD KEY');
-//         $invalidSelfMailerApi = new SelfMailersApi($wrongConfig);
+        // create editable self-mailer
+        self::$editableSelfMailer = new SelfMailerEditable();
+        self::$editableSelfMailer->setTo(self::$toAddress->getId());
+        self::$editableSelfMailer->setFrom(self::$fromAddress->getId());
+        self::$editableSelfMailer->setDescription("Dummy Self-Mailer (Integration Test)");
+        self::$editableSelfMailer->setInside("https://s3.us-west-2.amazonaws.com/public.lob.com/assets/templates/self_mailers/6x18_sfm_inside.pdf");
+        self::$editableSelfMailer->setOutside("https://s3.us-west-2.amazonaws.com/public.lob.com/assets/templates/self_mailers/6x18_sfm_inside.pdf");
 
-//         // create editable self-mailer
-//         self::$editableSelfMailer = new SelfMailerEditable();
-//         self::$editableSelfMailer->setTo(self::$toAddress->getId());
-//         self::$editableSelfMailer->setFrom(self::$fromAddress->getId());
-//         self::$editableSelfMailer->setDescription("Dummy Self-Mailer (Integration Test)");
-//         self::$editableSelfMailer->setInside("https://s3.us-west-2.amazonaws.com/public.lob.com/assets/templates/self_mailers/6x18_sfm_inside.pdf");
-//         self::$editableSelfMailer->setOutside("https://s3.us-west-2.amazonaws.com/public.lob.com/assets/templates/self_mailers/6x18_sfm_inside.pdf");
+        // create second editable self-mailer
+        self::$editableSelfMailer2 = new SelfMailerEditable();
+        self::$editableSelfMailer2->setTo(self::$toAddress2->getId());
+        self::$editableSelfMailer2->setFrom(self::$fromAddress2->getId());
+        self::$editableSelfMailer2->setDescription("Dummy Self-Mailer (Integration Test)");
+        self::$editableSelfMailer2->setInside("https://s3.us-west-2.amazonaws.com/public.lob.com/assets/templates/self_mailers/6x18_sfm_inside.pdf");
+        self::$editableSelfMailer2->setOutside("https://s3.us-west-2.amazonaws.com/public.lob.com/assets/templates/self_mailers/6x18_sfm_inside.pdf");
+        self::$metadata = (object)array("name"=>"Harry");
+        self::$editableSelfMailer2->setMetadata(self::$metadata);
 
-//         // create second editable self-mailer
-//         self::$editableSelfMailer2 = new SelfMailerEditable();
-//         self::$editableSelfMailer2->setTo(self::$toAddress2->getId());
-//         self::$editableSelfMailer2->setFrom(self::$fromAddress2->getId());
-//         self::$editableSelfMailer2->setDescription("Dummy Self-Mailer (Integration Test)");
-//         self::$editableSelfMailer2->setInside("https://s3.us-west-2.amazonaws.com/public.lob.com/assets/templates/self_mailers/6x18_sfm_inside.pdf");
-//         self::$editableSelfMailer2->setOutside("https://s3.us-west-2.amazonaws.com/public.lob.com/assets/templates/self_mailers/6x18_sfm_inside.pdf");
-//         self::$metadata = (object)array("name"=>"Harry");
-//         self::$editableSelfMailer2->setMetadata(self::$metadata);
+        // create error self-mailer
+        self::$errorSelfMailer = new SelfMailerEditable();
+        self::$errorSelfMailer->setFrom(self::$fromAddress->getId());
+        self::$errorSelfMailer->setDescription("Dummy Self-Mailer (Integration Test)");
+        self::$errorSelfMailer->setInside("https://s3.us-west-2.amazonaws.com/public.lob.com/assets/templates/self_mailers/6x18_sfm_inside.pdf");
+        self::$errorSelfMailer->setOutside("https://s3.us-west-2.amazonaws.com/public.lob.com/assets/templates/self_mailers/6x18_sfm_inside.pdf");
+    }
 
-//         // create error self-mailer
-//         self::$errorSelfMailer = new SelfMailerEditable();
-//         self::$errorSelfMailer->setFrom(self::$fromAddress->getId());
-//         self::$errorSelfMailer->setDescription("Dummy Self-Mailer (Integration Test)");
-//         self::$errorSelfMailer->setInside("https://s3.us-west-2.amazonaws.com/public.lob.com/assets/templates/self_mailers/6x18_sfm_inside.pdf");
-//         self::$errorSelfMailer->setOutside("https://s3.us-west-2.amazonaws.com/public.lob.com/assets/templates/self_mailers/6x18_sfm_inside.pdf");
-//     }
+    public function tearDown(): void
+    {
+        foreach ($this->idsForCleanup as $id) {
+            self::$selfMailersApi->delete($id);
+        }
+    }
 
-//     public function tearDown(): void
-//     {
-//         foreach ($this->idsForCleanup as $id) {
-//             self::$selfMailersApi->delete($id);
-//         }
-//     }
+    public static function tearDownAfterClass(): void {
+        self::$addressApi->delete(self::$toAddress->getId());
+        self::$addressApi->delete(self::$toAddress2->getId());
+        self::$addressApi->delete(self::$fromAddress->getId());
+        self::$addressApi->delete(self::$fromAddress2->getId());
+    }
 
-//     public static function tearDownAfterClass(): void {
-//         self::$addressApi->delete(self::$toAddress->getId());
-//         self::$addressApi->delete(self::$toAddress2->getId());
-//         self::$addressApi->delete(self::$fromAddress->getId());
-//         self::$addressApi->delete(self::$fromAddress2->getId());
-//     }
+    public function testSelfMailersApiInstantiation200() {
+        $selfMailersApi200 = new SelfMailersApi(self::$config);
+        $this->assertEquals(gettype($selfMailersApi200), 'object');
+    }
 
-//     public function testSelfMailersApiInstantiation200() {
-//         $selfMailersApi200 = new SelfMailersApi(self::$config);
-//         $this->assertEquals(gettype($selfMailersApi200), 'object');
-//     }
+    public function testCreate200()
+    {
+        $createdSelfMailer = self::$selfMailersApi->create(self::$editableSelfMailer);
+        $this->assertMatchesRegularExpression('/sfm_/', $createdSelfMailer->getId());
+        array_push($this->idsForCleanup, $createdSelfMailer->getId());
+    }
 
-//     public function testCreate200()
-//     {
-//         $createdSelfMailer = self::$selfMailersApi->create(self::$editableSelfMailer);
-//         $this->assertMatchesRegularExpression('/sfm_/', $createdSelfMailer->getId());
-//         array_push($this->idsForCleanup, $createdSelfMailer->getId());
-//     }
+    // does not include required field in request
+    public function testCreate422()
+    {
+        $this->expectException(ApiException::class);
+        $this->expectExceptionMessageMatches("/to is required/");
+        $errorResponse = self::$selfMailersApi->create(self::$errorSelfMailer);
+    }
 
-//     // does not include required field in request
-//     public function testCreate422()
-//     {
-//         $this->expectException(ApiException::class);
-//         $this->expectExceptionMessageMatches("/to is required/");
-//         $errorResponse = self::$selfMailersApi->create(self::$errorSelfMailer);
-//     }
+    // uses a bad key to attempt to send a request
+    public function testSelfMailerApi401() {
+        $wrongConfig = new Configuration();
+        $wrongConfig->setApiKey('basic', 'BAD KEY');
+        $selfMailersApiError = new SelfMailersApi($wrongConfig);
 
-//     // uses a bad key to attempt to send a request
-//     public function testSelfMailerApi401() {
-//         $wrongConfig = new Configuration();
-//         $wrongConfig->setApiKey('basic', 'BAD KEY');
-//         $selfMailersApiError = new SelfMailersApi($wrongConfig);
+        $this->expectException(ApiException::class);
+        $this->expectExceptionMessageMatches("/Your API key is not valid. Please sign up on lob.com to get a valid api key./");
+        $errorResponse = $selfMailersApiError->create(self::$editableSelfMailer);
+    }
 
-//         $this->expectException(ApiException::class);
-//         $this->expectExceptionMessageMatches("/Your API key is not valid. Please sign up on lob.com to get a valid api key./");
-//         $errorResponse = $selfMailersApiError->create(self::$editableSelfMailer);
-//     }
+    public function testGet200()
+    {
+        $createdSelfMailer = self::$selfMailersApi->create(self::$editableSelfMailer);
+        $retrievedSelfMailer = self::$selfMailersApi->get($createdSelfMailer->getId());
+        $this->assertEquals($createdSelfMailer->getTo(), $retrievedSelfMailer->getTo());
+        array_push($this->idsForCleanup, $createdSelfMailer->getId());
+    }
 
-//     public function testGet200()
-//     {
-//         $createdSelfMailer = self::$selfMailersApi->create(self::$editableSelfMailer);
-//         $retrievedSelfMailer = self::$selfMailersApi->get($createdSelfMailer->getId());
-//         $this->assertEquals($createdSelfMailer->getTo(), $retrievedSelfMailer->getTo());
-//         array_push($this->idsForCleanup, $createdSelfMailer->getId());
-//     }
+    public function testGet0()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches("/Missing the required parameter/");
+        $badRetrieval = self::$selfMailersApi->get(null);
+    }
 
-//     public function testGet0()
-//     {
-//         $this->expectException(\InvalidArgumentException::class);
-//         $this->expectExceptionMessageMatches("/Missing the required parameter/");
-//         $badRetrieval = self::$selfMailersApi->get(null);
-//     }
+    public function testGet401()
+    {
+        $createdSelfMailers = self::$selfMailersApi->create(self::$editableSelfMailer);
+        array_push($this->idsForCleanup, $createdSelfMailers->getId());
 
-//     public function testGet401()
-//     {
-//         $createdSelfMailers = self::$selfMailersApi->create(self::$regularSelfMailers);
-//         array_push($this->idsForCleanup, $createdSelfMailers->getId());
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessageMatches("/Your API key is not valid/");
+        $badRetrieval = self::$invalidSelfMailerApi->get($createdSelfMailers->getId());
+    }
 
-//         $this->expectException(\Exception::class);
-//         $this->expectExceptionMessageMatches("/Your API key is not valid/");
-//         $badRetrieval = self::$invalidSelfMailerApi->get($createdSelfMailers->getId());
-//     }
+    public function testGet404()
+    {
+        $this->expectException(ApiException::class);
+        $this->expectExceptionMessageMatches("/self mailer not found/");
+        $badRetrieval = self::$selfMailersApi->get("sfm_NONEXISTENT");
+    }
 
-//     public function testGet404()
-//     {
-//         $this->expectException(ApiException::class);
-//         $this->expectExceptionMessageMatches("/self mailer not found/");
-//         $badRetrieval = self::$selfMailersApi->get("sfm_NONEXISTENT");
-//     }
+    public function testList200()
+    {
+        $nextUrl = "";
+        $previousUrl = "";
+        $sfm1 = self::$selfMailersApi->create(self::$editableSelfMailer);
+        $sfm2 = self::$selfMailersApi->create(self::$editableSelfMailer2);
+        $listedSelfMailers = self::$selfMailersApi->list(2);
+        $this->assertGreaterThan(1, count($listedSelfMailers->getData()));
+        $this->assertLessThanOrEqual(2, count($listedSelfMailers->getData()));
+        $nextUrl = substr($listedSelfMailers->getNextUrl(), strrpos($listedSelfMailers->getNextUrl(), "after=") + 6);
+        $this->assertIsString($nextUrl);
+        array_push($this->idsForCleanup, $sfm1->getId());
+        array_push($this->idsForCleanup, $sfm2->getId());
 
-//     public function testList200()
-//     {
-//         $nextUrl = "";
-//         $previousUrl = "";
-//         $sfm1 = self::$selfMailersApi->create(self::$editableSelfMailer);
-//         $sfm2 = self::$selfMailersApi->create(self::$editableSelfMailer2);
-//         $listedSelfMailers = self::$selfMailersApi->list(2);
-//         $this->assertGreaterThan(1, count($listedSelfMailers->getData()));
-//         $this->assertLessThanOrEqual(2, count($listedSelfMailers->getData()));
-//         $nextUrl = substr($listedSelfMailers->getNextUrl(), strrpos($listedSelfMailers->getNextUrl(), "after=") + 6);
-//         $this->assertIsString($nextUrl);
-//         array_push($this->idsForCleanup, $sfm1->getId());
-//         array_push($this->idsForCleanup, $sfm2->getId());
+        // response using nextUrl
+        if ($nextUrl != "") {
+            $sfm1 = self::$selfMailersApi->create(self::$editableSelfMailer);
+            $sfm2 = self::$selfMailersApi->create(self::$editableSelfMailer2);
+            $listedSelfMailersAfter = self::$selfMailersApi->list(2, null, $nextUrl);
+            $this->assertGreaterThan(1, count($listedSelfMailersAfter->getData()));
+            $this->assertLessThanOrEqual(2, count($listedSelfMailersAfter->getData()));
+            $previousUrl = substr($listedSelfMailersAfter->getPreviousUrl(), strrpos($listedSelfMailersAfter->getPreviousUrl(), "before=") + 7);
+            $this->assertIsString($previousUrl);
+            array_push($this->idsForCleanup, $sfm1->getId());
+            array_push($this->idsForCleanup, $sfm2->getId());
+        }
 
-//         // response using nextUrl
-//         if ($nextUrl != "") {
-//             $sfm1 = self::$selfMailersApi->create(self::$editableSelfMailer);
-//             $sfm2 = self::$selfMailersApi->create(self::$editableSelfMailer2);
-//             $listedSelfMailersAfter = self::$selfMailersApi->list(2, null, $nextUrl);
-//             $this->assertGreaterThan(1, count($listedSelfMailersAfter->getData()));
-//             $this->assertLessThanOrEqual(2, count($listedSelfMailersAfter->getData()));
-//             $previousUrl = substr($listedSelfMailersAfter->getPreviousUrl(), strrpos($listedSelfMailersAfter->getPreviousUrl(), "before=") + 7);
-//             $this->assertIsString($previousUrl);
-//             array_push($this->idsForCleanup, $sfm1->getId());
-//             array_push($this->idsForCleanup, $sfm2->getId());
-//         }
+        // response using previousUrl
+        if ($previousUrl != "") {
+            $sfm1 = self::$selfMailersApi->create(self::$editableSelfMailer);
+            $sfm2 = self::$selfMailersApi->create(self::$editableSelfMailer2);
+            $listedSelfMailersBefore = self::$selfMailersApi->list(2, $previousUrl);
+            $this->assertGreaterThan(1, count($listedSelfMailersBefore->getData()));
+            $this->assertLessThanOrEqual(2, count($listedSelfMailersBefore->getData()));
+            array_push($this->idsForCleanup, $sfm1->getId());
+            array_push($this->idsForCleanup, $sfm2->getId());
+        }
+    }
 
-//         // response using previousUrl
-//         if ($previousUrl != "") {
-//             $sfm1 = self::$selfMailersApi->create(self::$editableSelfMailer);
-//             $sfm2 = self::$selfMailersApi->create(self::$editableSelfMailer2);
-//             $listedSelfMailersBefore = self::$selfMailersApi->list(2, $previousUrl);
-//             $this->assertGreaterThan(1, count($listedSelfMailersBefore->getData()));
-//             $this->assertLessThanOrEqual(2, count($listedSelfMailersBefore->getData()));
-//             array_push($this->idsForCleanup, $sfm1->getId());
-//             array_push($this->idsForCleanup, $sfm2->getId());
-//         }
-//     }
+    public function provider()
+    {
+        return array(
+            // array(null, null, null, array("total_count"), null, null, null, null, null, null, null), // include
+            // array(null, null, null, null, array("gt" => (string)(date("c")), "lt" => (string)(date("c", time() + 86400))), null, null, null, null, null, null), // date_created
+            array(null, null, null, null, null, self::$metadata, null, null, null, null, null), // metadata
+            // array(null, null, null, null, null, null, [SelfMailerSize::_6X18_BIFOLD->value], null, null, null, null), // size
+            // array(null, null, null, null, null, null, null, TRUE, null, null, null), // scheduled
+            // array(null, null, null, null, null, null, null, null, array("gt" => (string)(date("c")), "lt" => (string)(date("c", time() + 86400))), null, null), // send_date
+            array(null, null, null, null, null, null, null, null, null, MailType::FIRST_CLASS->value, null), // mail_type
+            array(null, null, null, null, null, null, null, null, null, null, new SortBy5(array("date_created" => "asc"))) // sort_by
+        );
+    }
 
-//     public function provider()
-//     {
-//         return array(
-//             // array(null, null, null, array("total_count"), null, null, null, null, null, null, null), // include
-//             // array(null, null, null, null, array("gt" => (string)(date("c")), "lt" => (string)(date("c", time() + 86400))), null, null, null, null, null, null), // date_created
-//             array(null, null, null, null, null, self::$metadata, null, null, null, null, null), // metadata
-//             // array(null, null, null, null, null, null, [SelfMailerSize::_6X18_BIFOLD->value], null, null, null, null), // size
-//             // array(null, null, null, null, null, null, null, TRUE, null, null, null), // scheduled
-//             // array(null, null, null, null, null, null, null, null, array("gt" => (string)(date("c")), "lt" => (string)(date("c", time() + 86400))), null, null), // send_date
-//             array(null, null, null, null, null, null, null, null, null, MailType::FIRST_CLASS->value, null), // mail_type
-//             array(null, null, null, null, null, null, null, null, null, null, new SortBy5(array("date_created" => "asc"))) // sort_by
-//         );
-//     }
+    /**
+     * @dataProvider provider
+     */
+    public function testListWithParams($limit, $before, $after, $include, $date_created, $metadata, $size, $scheduled, $send_date, $mail_type, $sort_by)
+    {
+        // create self mailers to list
+        $sfm1 = self::$selfMailersApi->create(self::$editableSelfMailer);
+        $sfm2 = self::$selfMailersApi->create(self::$editableSelfMailer2);
+        $listedSelfMailers = self::$selfMailersApi->list($limit, $before, $after, $include, $date_created, $metadata, $size, $scheduled, $send_date, $mail_type, $sort_by);
 
-//     /**
-//      * @dataProvider provider
-//      */
-//     public function testListWithParams($limit, $before, $after, $include, $date_created, $metadata, $size, $scheduled, $send_date, $mail_type, $sort_by)
-//     {
-//         // create self mailers to list
-//         $sfm1 = self::$selfMailersApi->create(self::$editableSelfMailer);
-//         $sfm2 = self::$selfMailersApi->create(self::$editableSelfMailer2);
-//         $listedSelfMailers = self::$selfMailersApi->list($limit, $before, $after, $include, $date_created, $metadata, $size, $scheduled, $send_date, $mail_type, $sort_by);
+        $this->assertGreaterThan(0, $listedSelfMailers->getCount());
+        if ($include) $this->assertNotNull($listedSelfMailers->getTotalCount());
 
-//         $this->assertGreaterThan(0, $listedSelfMailers->getCount());
-//         if ($include) $this->assertNotNull($listedSelfMailers->getTotalCount());
+        // delete created self mailers
+        array_push($this->idsForCleanup, $sfm1->getId());
+        array_push($this->idsForCleanup, $sfm2->getId());
+    }
 
-//         // delete created self mailers
-//         array_push($this->idsForCleanup, $sfm1->getId());
-//         array_push($this->idsForCleanup, $sfm2->getId());
-//     }
+    public function testDelete200()
+    {
+        $createdSelfMailer = self::$selfMailersApi->create(self::$editableSelfMailer);
+        $deletedSelfMailer = self::$selfMailersApi->delete($createdSelfMailer->getId());
+        $this->assertEquals(true, $deletedSelfMailer->getDeleted());
+    }
 
-//     public function testDelete200()
-//     {
-//         $createdSelfMailer = self::$selfMailersApi->create(self::$editableSelfMailer);
-//         $deletedSelfMailer = self::$selfMailersApi->delete($createdSelfMailer->getId());
-//         $this->assertEquals(true, $deletedSelfMailer->getDeleted());
-//     }
+    public function testDelete401()
+    {
+        $createdSelfMailer = self::$selfMailersApi->create(self::$editableSelfMailer);
+        array_push($this->idsForCleanup, $createdSelfMailer->getId());
 
-//     public function testDelete401()
-//     {
-//         $createdSelfMailer = self::$selfMailersApi->create(self::$editableSelfMailer);
-//         array_push($this->idsForCleanup, $createdSelfMailer->getId());
+        $this->expectException(ApiException::class);
+        $this->expectExceptionMessageMatches("/Your API key is not valid. Please sign up on lob.com to get a valid api key./");
+        $deletedSelfMailer = self::$invalidSelfMailerApi->delete($createdSelfMailer->getId());
+    }
 
-//         $this->expectException(ApiException::class);
-//         $this->expectExceptionMessageMatches("/Your API key is not valid. Please sign up on lob.com to get a valid api key./");
-//         $deletedSelfMailer = self::$invalidSelfMailerApi->delete($createdSelfMailer->getId());
-//     }
-
-//     public function testDelete404()
-//     {
-//         $this->expectException(ApiException::class);
-//         $this->expectExceptionMessageMatches("/self mailer not found/");
-//         $badDeletion = self::$selfMailersApi->delete("sfm_NONEXISTENT");
-//     }
-// }
+    public function testDelete404()
+    {
+        $this->expectException(ApiException::class);
+        $this->expectExceptionMessageMatches("/self mailer not found/");
+        $badDeletion = self::$selfMailersApi->delete("sfm_NONEXISTENT");
+    }
+}

--- a/test/Integration/SelfMailersApiSpecTest.php
+++ b/test/Integration/SelfMailersApiSpecTest.php
@@ -160,15 +160,23 @@ class SelfMailersApiSpecTest extends TestCase
     }
 
     public function testSelfMailersApiInstantiation200() {
-        $selfMailersApi200 = new SelfMailersApi(self::$config);
-        $this->assertEquals(gettype($selfMailersApi200), 'object');
+        try {
+            $selfMailersApi200 = new SelfMailersApi(self::$config);
+            $this->assertEquals(gettype($selfMailersApi200), 'object');
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+        }
     }
 
     public function testCreate200()
     {
-        $createdSelfMailer = self::$selfMailersApi->create(self::$editableSelfMailer);
-        $this->assertMatchesRegularExpression('/sfm_/', $createdSelfMailer->getId());
-        array_push($this->idsForCleanup, $createdSelfMailer->getId());
+        try {
+            $createdSelfMailer = self::$selfMailersApi->create(self::$editableSelfMailer);
+            $this->assertMatchesRegularExpression('/sfm_/', $createdSelfMailer->getId());
+            array_push($this->idsForCleanup, $createdSelfMailer->getId());
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+        }
     }
 
     // does not include required field in request
@@ -192,10 +200,14 @@ class SelfMailersApiSpecTest extends TestCase
 
     public function testGet200()
     {
-        $createdSelfMailer = self::$selfMailersApi->create(self::$editableSelfMailer);
-        $retrievedSelfMailer = self::$selfMailersApi->get($createdSelfMailer->getId());
-        $this->assertEquals($createdSelfMailer->getTo(), $retrievedSelfMailer->getTo());
-        array_push($this->idsForCleanup, $createdSelfMailer->getId());
+        try {
+            $createdSelfMailer = self::$selfMailersApi->create(self::$editableSelfMailer);
+            $retrievedSelfMailer = self::$selfMailersApi->get($createdSelfMailer->getId());
+            $this->assertEquals($createdSelfMailer->getTo(), $retrievedSelfMailer->getTo());
+            array_push($this->idsForCleanup, $createdSelfMailer->getId());
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+        }
     }
 
     public function testGet0()
@@ -226,38 +238,50 @@ class SelfMailersApiSpecTest extends TestCase
     {
         $nextUrl = "";
         $previousUrl = "";
-        $sfm1 = self::$selfMailersApi->create(self::$editableSelfMailer);
-        $sfm2 = self::$selfMailersApi->create(self::$editableSelfMailer2);
-        $listedSelfMailers = self::$selfMailersApi->list(2);
-        $this->assertGreaterThan(1, count($listedSelfMailers->getData()));
-        $this->assertLessThanOrEqual(2, count($listedSelfMailers->getData()));
-        $nextUrl = substr($listedSelfMailers->getNextUrl(), strrpos($listedSelfMailers->getNextUrl(), "after=") + 6);
-        $this->assertIsString($nextUrl);
-        array_push($this->idsForCleanup, $sfm1->getId());
-        array_push($this->idsForCleanup, $sfm2->getId());
+        try {
+            $sfm1 = self::$selfMailersApi->create(self::$editableSelfMailer);
+            $sfm2 = self::$selfMailersApi->create(self::$editableSelfMailer2);
+            $listedSelfMailers = self::$selfMailersApi->list(2);
+            $this->assertGreaterThan(1, count($listedSelfMailers->getData()));
+            $this->assertLessThanOrEqual(2, count($listedSelfMailers->getData()));
+            $nextUrl = substr($listedSelfMailers->getNextUrl(), strrpos($listedSelfMailers->getNextUrl(), "after=") + 6);
+            $this->assertIsString($nextUrl);
+            array_push($this->idsForCleanup, $sfm1->getId());
+            array_push($this->idsForCleanup, $sfm2->getId());
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+        }
 
         // response using nextUrl
         if ($nextUrl != "") {
-            $sfm1 = self::$selfMailersApi->create(self::$editableSelfMailer);
-            $sfm2 = self::$selfMailersApi->create(self::$editableSelfMailer2);
-            $listedSelfMailersAfter = self::$selfMailersApi->list(2, null, $nextUrl);
-            $this->assertGreaterThan(1, count($listedSelfMailersAfter->getData()));
-            $this->assertLessThanOrEqual(2, count($listedSelfMailersAfter->getData()));
-            $previousUrl = substr($listedSelfMailersAfter->getPreviousUrl(), strrpos($listedSelfMailersAfter->getPreviousUrl(), "before=") + 7);
-            $this->assertIsString($previousUrl);
-            array_push($this->idsForCleanup, $sfm1->getId());
-            array_push($this->idsForCleanup, $sfm2->getId());
+            try {
+                $sfm1 = self::$selfMailersApi->create(self::$editableSelfMailer);
+                $sfm2 = self::$selfMailersApi->create(self::$editableSelfMailer2);
+                $listedSelfMailersAfter = self::$selfMailersApi->list(2, null, $nextUrl);
+                $this->assertGreaterThan(1, count($listedSelfMailersAfter->getData()));
+                $this->assertLessThanOrEqual(2, count($listedSelfMailersAfter->getData()));
+                $previousUrl = substr($listedSelfMailersAfter->getPreviousUrl(), strrpos($listedSelfMailersAfter->getPreviousUrl(), "before=") + 7);
+                $this->assertIsString($previousUrl);
+                array_push($this->idsForCleanup, $sfm1->getId());
+                array_push($this->idsForCleanup, $sfm2->getId());
+            } catch (\Exception $e) {
+                throw new \Exception($e->getMessage());
+            }
         }
 
         // response using previousUrl
         if ($previousUrl != "") {
-            $sfm1 = self::$selfMailersApi->create(self::$editableSelfMailer);
-            $sfm2 = self::$selfMailersApi->create(self::$editableSelfMailer2);
-            $listedSelfMailersBefore = self::$selfMailersApi->list(2, $previousUrl);
-            $this->assertGreaterThan(1, count($listedSelfMailersBefore->getData()));
-            $this->assertLessThanOrEqual(2, count($listedSelfMailersBefore->getData()));
-            array_push($this->idsForCleanup, $sfm1->getId());
-            array_push($this->idsForCleanup, $sfm2->getId());
+            try {
+                $sfm1 = self::$selfMailersApi->create(self::$editableSelfMailer);
+                $sfm2 = self::$selfMailersApi->create(self::$editableSelfMailer2);
+                $listedSelfMailersBefore = self::$selfMailersApi->list(2, $previousUrl);
+                $this->assertGreaterThan(1, count($listedSelfMailersBefore->getData()));
+                $this->assertLessThanOrEqual(2, count($listedSelfMailersBefore->getData()));
+                array_push($this->idsForCleanup, $sfm1->getId());
+                array_push($this->idsForCleanup, $sfm2->getId());
+            } catch (\Exception $e) {
+                throw new \Exception($e->getMessage());
+            }
         }
     }
 
@@ -284,24 +308,32 @@ class SelfMailersApiSpecTest extends TestCase
      */
     public function testListWithParams($limit, $before, $after, $include, $date_created, $metadata, $size, $scheduled, $send_date, $mail_type, $sort_by)
     {
+        try {
         // create self mailers to list
-        $sfm1 = self::$selfMailersApi->create(self::$editableSelfMailer);
-        $sfm2 = self::$selfMailersApi->create(self::$editableSelfMailer2);
-        $listedSelfMailers = self::$selfMailersApi->list($limit, $before, $after, $include, $date_created, $metadata, $size, $scheduled, $send_date, $mail_type, $sort_by);
+            $sfm1 = self::$selfMailersApi->create(self::$editableSelfMailer);
+            $sfm2 = self::$selfMailersApi->create(self::$editableSelfMailer2);
+            $listedSelfMailers = self::$selfMailersApi->list($limit, $before, $after, $include, $date_created, $metadata, $size, $scheduled, $send_date, $mail_type, $sort_by);
 
-        $this->assertGreaterThan(0, $listedSelfMailers->getCount());
-        if ($include) $this->assertNotNull($listedSelfMailers->getTotalCount());
+            $this->assertGreaterThan(0, $listedSelfMailers->getCount());
+            if ($include) $this->assertNotNull($listedSelfMailers->getTotalCount());
 
-        // delete created self mailers
-        array_push($this->idsForCleanup, $sfm1->getId());
-        array_push($this->idsForCleanup, $sfm2->getId());
+            // delete created self mailers
+            array_push($this->idsForCleanup, $sfm1->getId());
+            array_push($this->idsForCleanup, $sfm2->getId());
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+        }
     }
 
     public function testDelete200()
     {
-        $createdSelfMailer = self::$selfMailersApi->create(self::$editableSelfMailer);
-        $deletedSelfMailer = self::$selfMailersApi->delete($createdSelfMailer->getId());
-        $this->assertEquals(true, $deletedSelfMailer->getDeleted());
+        try {
+            $createdSelfMailer = self::$selfMailersApi->create(self::$editableSelfMailer);
+            $deletedSelfMailer = self::$selfMailersApi->delete($createdSelfMailer->getId());
+            $this->assertEquals(true, $deletedSelfMailer->getDeleted());
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+        }
     }
 
     public function testDelete401()

--- a/test/Integration/SelfMailersApiSpecTest.php
+++ b/test/Integration/SelfMailersApiSpecTest.php
@@ -26,271 +26,296 @@
  * Please update the test case below to test the endpoint.
  */
 
-namespace OpenAPI\Client\Test\Api;
+// TODO: commented this whole test file since selfMailer objects aren't deserialized properly
 
-use \OpenAPI\Client\Configuration;
-use \OpenAPI\Client\ApiException;
-use PHPUnit\Framework\TestCase;
-use \OpenAPI\Client\Model\SelfMailerEditable;
-use \OpenAPI\Client\Api\SelfMailersApi;
-use \OpenAPI\Client\Model\AddressEditable;
-use \OpenAPI\Client\Api\AddressesApi;
+// namespace OpenAPI\Client\Test\Api;
 
-/**
- * AddressesApiTest Class Doc Comment
- *
- * @category Class
- * @package  OpenAPI\Client
- * @author   OpenAPI Generator team
- * @link     https://openapi-generator.tech
- */
+// use \OpenAPI\Client\Configuration;
+// use \OpenAPI\Client\ApiException;
+// use PHPUnit\Framework\TestCase;
+// use \OpenAPI\Client\Model\SelfMailerEditable;
+// use \OpenAPI\Client\Api\SelfMailersApi;
+// use \OpenAPI\Client\Model\AddressEditable;
+// use \OpenAPI\Client\Api\AddressesApi;
+// use \OpenAPI\Client\Model\SelfMailerSize;
+// use \OpenAPI\Client\Model\MailType;
+// use \OpenAPI\Client\Model\SortBy5;
+// /**
+//  * AddressesApiTest Class Doc Comment
+//  *
+//  * @category Class
+//  * @package  OpenAPI\Client
+//  * @author   OpenAPI Generator team
+//  * @link     https://openapi-generator.tech
+//  */
 
-class SelfMailersApiSpecTest extends TestCase
-{
-    /**
-     * Setup before running any test cases
-     */
-    private static $config;
-    private static $addressApi;
-    private static $selfMailersApi;
-    private static $editableSelfMailer;
-    private static $editableSelfMailer2;
-    private static $errorSelfMailer;
+// class SelfMailersApiSpecTest extends TestCase
+// {
+//     /**
+//      * Setup before running any test cases
+//      */
+//     private static $config;
+//     private static $addressApi;
+//     private static $selfMailersApi;
+//     private static $invalidSelfMailerApi;
+//     private static $editableSelfMailer;
+//     private static $editableSelfMailer2;
+//     private static $errorSelfMailer;
+//     private static $metadata;
 
-    // for teardown post-testing
-    private $idsForCleanup = [];
-    private static $toAddress;
-    private static $fromAddress;
-    private static $toAddress2;
-    private static $fromAddress2;
+//     // for teardown post-testing
+//     private $idsForCleanup = [];
+//     private static $toAddress;
+//     private static $fromAddress;
+//     private static $toAddress2;
+//     private static $fromAddress2;
 
-    // set up constant fixtures
-    public static function setUpBeforeClass(): void
-    {
-        // create instance of AddressesApi & addresses to use for other tests
-        self::$config = new Configuration();
-        self::$config->setApiKey('basic', getenv('LOB_API_TEST_KEY'));
-        self::$addressApi = new AddressesApi(self::$config);
+//     // set up constant fixtures
+//     public static function setUpBeforeClass(): void
+//     {
+//         // create instance of AddressesApi & addresses to use for other tests
+//         self::$config = new Configuration();
+//         self::$config->setApiKey('basic', getenv('LOB_API_TEST_KEY'));
+//         self::$addressApi = new AddressesApi(self::$config);
 
-        $address1 = new AddressEditable();
-        $address1->setName("THING T. THING");
-        $address1->setAddressLine1("1313 CEMETERY LN");
-        $address1->setAddressCity("WESTFIELD");
-        $address1->setAddressState("NJ");
-        $address1->setAddressZip("07000");
+//         $address1 = new AddressEditable();
+//         $address1->setName("THING T. THING");
+//         $address1->setAddressLine1("1313 CEMETERY LN");
+//         $address1->setAddressCity("WESTFIELD");
+//         $address1->setAddressState("NJ");
+//         $address1->setAddressZip("07000");
 
-        $address2 = new AddressEditable();
-        $address2->setName("FESTER");
-        $address2->setAddressLine1("001 CEMETERY LN");
-        $address2->setAddressLine2("SUITE 666");
-        $address2->setAddressCity("WESTFIELD");
-        $address2->setAddressState("NJ");
-        $address2->setAddressZip("07000");
+//         $address2 = new AddressEditable();
+//         $address2->setName("FESTER");
+//         $address2->setAddressLine1("001 CEMETERY LN");
+//         $address2->setAddressLine2("SUITE 666");
+//         $address2->setAddressCity("WESTFIELD");
+//         $address2->setAddressState("NJ");
+//         $address2->setAddressZip("07000");
 
-        self::$toAddress = self::$addressApi->create($address1);
-        self::$fromAddress = self::$addressApi->create($address2);
+//         self::$toAddress = self::$addressApi->create($address1);
+//         self::$fromAddress = self::$addressApi->create($address2);
 
-        $address3 = new AddressEditable();
-        $address3->setName("MORTICIA ADDAMS");
-        $address3->setAddressLine1("1212 CEMETERY LN");
-        $address3->setAddressCity("WESTFIELD");
-        $address3->setAddressState("NJ");
-        $address3->setAddressZip("07000");
+//         $address3 = new AddressEditable();
+//         $address3->setName("MORTICIA ADDAMS");
+//         $address3->setAddressLine1("1212 CEMETERY LN");
+//         $address3->setAddressCity("WESTFIELD");
+//         $address3->setAddressState("NJ");
+//         $address3->setAddressZip("07000");
 
-        $address4 = new AddressEditable();
-        $address4->setName("COUSIN ITT");
-        $address4->setAddressLine1("1515 CEMETERY LN");
-        $address4->setAddressLine2("FLOOR 0");
-        $address4->setAddressCity("WESTFIELD");
-        $address4->setAddressState("NJ");
-        $address4->setAddressZip("07000");
+//         $address4 = new AddressEditable();
+//         $address4->setName("COUSIN ITT");
+//         $address4->setAddressLine1("1515 CEMETERY LN");
+//         $address4->setAddressLine2("FLOOR 0");
+//         $address4->setAddressCity("WESTFIELD");
+//         $address4->setAddressState("NJ");
+//         $address4->setAddressZip("07000");
 
-        self::$toAddress2 = self::$addressApi->create($address3);
-        self::$fromAddress2 = self::$addressApi->create($address4);
+//         self::$toAddress2 = self::$addressApi->create($address3);
+//         self::$fromAddress2 = self::$addressApi->create($address4);
 
-        // create new instance of SelfMailersApi to use in other tests
-        self::$selfMailersApi = new SelfMailersApi(self::$config);
+//         // create new instance of SelfMailersApi to use in other tests
+//         self::$selfMailersApi = new SelfMailersApi(self::$config);
 
-        // create editable self-mailer
-        self::$editableSelfMailer = new SelfMailerEditable();
-        self::$editableSelfMailer->setTo(self::$toAddress->getId());
-        self::$editableSelfMailer->setFrom(self::$fromAddress->getId());
-        self::$editableSelfMailer->setDescription("Dummy Self-Mailer (Integration Test)");
-        self::$editableSelfMailer->setInside("https://s3.us-west-2.amazonaws.com/public.lob.com/assets/templates/self_mailers/6x18_sfm_inside.pdf");
-        self::$editableSelfMailer->setOutside("https://s3.us-west-2.amazonaws.com/public.lob.com/assets/templates/self_mailers/6x18_sfm_inside.pdf");
+//         $wrongConfig = new Configuration();
+//         $wrongConfig->setApiKey('basic', 'BAD KEY');
+//         $invalidSelfMailerApi = new SelfMailersApi($wrongConfig);
 
-        // create second editable self-mailer
-        self::$editableSelfMailer2 = new SelfMailerEditable();
-        self::$editableSelfMailer2->setTo(self::$toAddress2->getId());
-        self::$editableSelfMailer2->setFrom(self::$fromAddress2->getId());
-        self::$editableSelfMailer2->setDescription("Dummy Self-Mailer (Integration Test)");
-        self::$editableSelfMailer2->setInside("https://s3.us-west-2.amazonaws.com/public.lob.com/assets/templates/self_mailers/6x18_sfm_inside.pdf");
-        self::$editableSelfMailer2->setOutside("https://s3.us-west-2.amazonaws.com/public.lob.com/assets/templates/self_mailers/6x18_sfm_inside.pdf");
+//         // create editable self-mailer
+//         self::$editableSelfMailer = new SelfMailerEditable();
+//         self::$editableSelfMailer->setTo(self::$toAddress->getId());
+//         self::$editableSelfMailer->setFrom(self::$fromAddress->getId());
+//         self::$editableSelfMailer->setDescription("Dummy Self-Mailer (Integration Test)");
+//         self::$editableSelfMailer->setInside("https://s3.us-west-2.amazonaws.com/public.lob.com/assets/templates/self_mailers/6x18_sfm_inside.pdf");
+//         self::$editableSelfMailer->setOutside("https://s3.us-west-2.amazonaws.com/public.lob.com/assets/templates/self_mailers/6x18_sfm_inside.pdf");
 
-        // create error self-mailer
-        self::$errorSelfMailer = new SelfMailerEditable();
-        self::$errorSelfMailer->setFrom(self::$fromAddress->getId());
-        self::$errorSelfMailer->setDescription("Dummy Self-Mailer (Integration Test)");
-        self::$errorSelfMailer->setInside("https://s3.us-west-2.amazonaws.com/public.lob.com/assets/templates/self_mailers/6x18_sfm_inside.pdf");
-        self::$errorSelfMailer->setOutside("https://s3.us-west-2.amazonaws.com/public.lob.com/assets/templates/self_mailers/6x18_sfm_inside.pdf");
-    }
+//         // create second editable self-mailer
+//         self::$editableSelfMailer2 = new SelfMailerEditable();
+//         self::$editableSelfMailer2->setTo(self::$toAddress2->getId());
+//         self::$editableSelfMailer2->setFrom(self::$fromAddress2->getId());
+//         self::$editableSelfMailer2->setDescription("Dummy Self-Mailer (Integration Test)");
+//         self::$editableSelfMailer2->setInside("https://s3.us-west-2.amazonaws.com/public.lob.com/assets/templates/self_mailers/6x18_sfm_inside.pdf");
+//         self::$editableSelfMailer2->setOutside("https://s3.us-west-2.amazonaws.com/public.lob.com/assets/templates/self_mailers/6x18_sfm_inside.pdf");
+//         self::$metadata = (object)array("name"=>"Harry");
+//         self::$editableSelfMailer2->setMetadata(self::$metadata);
 
-    public function tearDown(): void
-    {
-        foreach ($this->idsForCleanup as $id) {
-            self::$selfMailersApi->delete($id);
-        }
-    }
+//         // create error self-mailer
+//         self::$errorSelfMailer = new SelfMailerEditable();
+//         self::$errorSelfMailer->setFrom(self::$fromAddress->getId());
+//         self::$errorSelfMailer->setDescription("Dummy Self-Mailer (Integration Test)");
+//         self::$errorSelfMailer->setInside("https://s3.us-west-2.amazonaws.com/public.lob.com/assets/templates/self_mailers/6x18_sfm_inside.pdf");
+//         self::$errorSelfMailer->setOutside("https://s3.us-west-2.amazonaws.com/public.lob.com/assets/templates/self_mailers/6x18_sfm_inside.pdf");
+//     }
 
-    public static function tearDownAfterClass(): void {
-        self::$addressApi->delete(self::$toAddress->getId());
-        self::$addressApi->delete(self::$toAddress2->getId());
-        self::$addressApi->delete(self::$fromAddress->getId());
-        self::$addressApi->delete(self::$fromAddress2->getId());
-    }
+//     public function tearDown(): void
+//     {
+//         foreach ($this->idsForCleanup as $id) {
+//             self::$selfMailersApi->delete($id);
+//         }
+//     }
 
-    // include static cleanup for all the addresses?
+//     public static function tearDownAfterClass(): void {
+//         self::$addressApi->delete(self::$toAddress->getId());
+//         self::$addressApi->delete(self::$toAddress2->getId());
+//         self::$addressApi->delete(self::$fromAddress->getId());
+//         self::$addressApi->delete(self::$fromAddress2->getId());
+//     }
 
-    public function testSelfMailersApiInstantiation200() {
-        try {
-            $selfMailersApi200 = new SelfMailersApi(self::$config);
-            $this->assertEquals(gettype($selfMailersApi200), 'object');
-        } catch (Exception $instantiationError) {
-            echo 'Caught exception: ',  $instantiationError->getMessage(), "\n";
-        }
-    }
+//     public function testSelfMailersApiInstantiation200() {
+//         $selfMailersApi200 = new SelfMailersApi(self::$config);
+//         $this->assertEquals(gettype($selfMailersApi200), 'object');
+//     }
 
-    public function testCreate200()
-    {
-        try {
-            $createdSelfMailer = self::$selfMailersApi->create(self::$editableSelfMailer);
-            $this->assertMatchesRegularExpression('/sfm_/', $createdSelfMailer->getId());
-            array_push($this->idsForCleanup, $createdSelfMailer->getId());
-        } catch (Exception $createError) {
-            echo 'Caught exception: ',  $createError->getMessage(), "\n";
-        }
-    }
+//     public function testCreate200()
+//     {
+//         $createdSelfMailer = self::$selfMailersApi->create(self::$editableSelfMailer);
+//         $this->assertMatchesRegularExpression('/sfm_/', $createdSelfMailer->getId());
+//         array_push($this->idsForCleanup, $createdSelfMailer->getId());
+//     }
 
-    // does not include required field in request
-    public function testCreate422()
-    {
-        try {
-            $this->expectException(ApiException::class);
-            $this->expectExceptionMessageMatches("/to is required/");
-            $errorResponse = self::$selfMailersApi->create(self::$errorSelfMailer);
-        } catch (Exception $createError) {
-            echo 'Caught exception: ',  $createError->getMessage(), "\n";
-        }
-    }
+//     // does not include required field in request
+//     public function testCreate422()
+//     {
+//         $this->expectException(ApiException::class);
+//         $this->expectExceptionMessageMatches("/to is required/");
+//         $errorResponse = self::$selfMailersApi->create(self::$errorSelfMailer);
+//     }
 
-    // uses a bad key to attempt to send a request
-    public function testSelfMailerApi401() {
-        try {
-            $wrongConfig = new Configuration();
-            $wrongConfig->setApiKey('basic', 'BAD KEY');
-            $selfMailerApiError = new SelfMailersApi($wrongConfig);
+//     // uses a bad key to attempt to send a request
+//     public function testSelfMailerApi401() {
+//         $wrongConfig = new Configuration();
+//         $wrongConfig->setApiKey('basic', 'BAD KEY');
+//         $selfMailersApiError = new SelfMailersApi($wrongConfig);
 
-            $this->expectException(ApiException::class);
-            $this->expectExceptionMessageMatches("/Your API key is not valid. Please sign up on lob.com to get a valid api key./");
-            $errorResponse = $selfMailerApiError->create(self::$editableSelfMailer);
-        } catch (Exception $instantiationError) {
-            echo 'Caught exception: ',  $instantiationError->getMessage(), "\n";
-        }
-    }
+//         $this->expectException(ApiException::class);
+//         $this->expectExceptionMessageMatches("/Your API key is not valid. Please sign up on lob.com to get a valid api key./");
+//         $errorResponse = $selfMailersApiError->create(self::$editableSelfMailer);
+//     }
 
-    public function testGet200()
-    {
-        try {
-            $createdSelfMailer = self::$selfMailersApi->create(self::$editableSelfMailer);
-            $retrievedPostcard = self::$selfMailersApi->get($createdSelfMailer->getId());
-            $this->assertEquals($createdSelfMailer->getTo(), $retrievedPostcard->getTo());
-            array_push($this->idsForCleanup, $createdSelfMailer->getId());
-        } catch (Exception $retrieveError) {
-            echo 'Caught exception: ',  $retrieveError->getMessage(), "\n";
-        }
-    }
+//     public function testGet200()
+//     {
+//         $createdSelfMailer = self::$selfMailersApi->create(self::$editableSelfMailer);
+//         $retrievedSelfMailer = self::$selfMailersApi->get($createdSelfMailer->getId());
+//         $this->assertEquals($createdSelfMailer->getTo(), $retrievedSelfMailer->getTo());
+//         array_push($this->idsForCleanup, $createdSelfMailer->getId());
+//     }
 
-    public function testGet404()
-    {
-        try {
-            $this->expectException(ApiException::class);
-            $this->expectExceptionMessageMatches("/self mailer not found/");
-            $badRetrieval = self::$selfMailersApi->get("sfm_NONEXISTENT");
-        } catch (Exception $retrieveError) {
-            echo 'Caught exception: ',  $retrieveError->getMessage(), "\n";
-        }
-    }
+//     public function testGet0()
+//     {
+//         $this->expectException(\InvalidArgumentException::class);
+//         $this->expectExceptionMessageMatches("/Missing the required parameter/");
+//         $badRetrieval = self::$selfMailersApi->get(null);
+//     }
 
-    public function testList200()
-    {
-        $nextUrl = "";
-        $previousUrl = "";
-        try {
-            $sfm1 = self::$selfMailersApi->create(self::$editableSelfMailer);
-            $sfm2 = self::$selfMailersApi->create(self::$editableSelfMailer2);
-            $listedSelfMailers = self::$selfMailersApi->list(2);
-            $this->assertGreaterThan(1, count($listedSelfMailers->getData()));
-            $this->assertLessThanOrEqual(2, count($listedSelfMailers->getData()));
-            $nextUrl = substr($listedSelfMailers->getNextUrl(), strrpos($listedSelfMailers->getNextUrl(), "after=") + 6);
-            $this->assertIsString($nextUrl);
-            array_push($this->idsForCleanup, $sfm1->getId());
-            array_push($this->idsForCleanup, $sfm2->getId());
-        } catch (Exception $listError) {
-            echo 'Caught exception: ',  $listError->getMessage(), "\n";
-        }
+//     public function testGet401()
+//     {
+//         $createdSelfMailers = self::$selfMailersApi->create(self::$regularSelfMailers);
+//         array_push($this->idsForCleanup, $createdSelfMailers->getId());
 
-        // response using nextUrl
-        if ($nextUrl != "") {
-            try {
-                $sfm1 = self::$selfMailersApi->create(self::$editableSelfMailer);
-                $sfm2 = self::$selfMailersApi->create(self::$editableSelfMailer2);
-                $listedSelfMailersAfter = self::$selfMailersApi->list(2, null, $nextUrl);
-                $this->assertGreaterThan(1, count($listedSelfMailersAfter->getData()));
-                $this->assertLessThanOrEqual(2, count($listedSelfMailersAfter->getData()));
-                $previousUrl = substr($listedSelfMailersAfter->getPreviousUrl(), strrpos($listedSelfMailersAfter->getPreviousUrl(), "before=") + 7);
-                $this->assertIsString($previousUrl);
-                array_push($this->idsForCleanup, $sfm1->getId());
-                array_push($this->idsForCleanup, $sfm2->getId());
-            } catch (Exception $listError) {
-                echo 'Caught exception: ',  $listError->getMessage(), "\n";
-            }
-        }
+//         $this->expectException(\Exception::class);
+//         $this->expectExceptionMessageMatches("/Your API key is not valid/");
+//         $badRetrieval = self::$invalidSelfMailerApi->get($createdSelfMailers->getId());
+//     }
 
-        // response using previousUrl
-        if ($previousUrl != "") {
-            try {
-                $sfm1 = self::$selfMailersApi->create(self::$editableSelfMailer);
-                $sfm2 = self::$selfMailersApi->create(self::$editableSelfMailer2);
-                $listedSelfMailersBefore = self::$selfMailersApi->list(2, $previousUrl);
-                $this->assertGreaterThan(1, count($listedSelfMailersBefore->getData()));
-                $this->assertLessThanOrEqual(2, count($listedSelfMailersBefore->getData()));
-                array_push($this->idsForCleanup, $sfm1->getId());
-                array_push($this->idsForCleanup, $sfm2->getId());
-            } catch (Exception $listError) {
-                echo 'Caught exception: ',  $listError->getMessage(), "\n";
-            }
-        }
-    }
+//     public function testGet404()
+//     {
+//         $this->expectException(ApiException::class);
+//         $this->expectExceptionMessageMatches("/self mailer not found/");
+//         $badRetrieval = self::$selfMailersApi->get("sfm_NONEXISTENT");
+//     }
 
-    public function testDelete200()
-    {
-        try {
-            $createdSelfMailer = self::$selfMailersApi->create(self::$editableSelfMailer);
-            $deletedSelfMailer = self::$selfMailersApi->delete($createdSelfMailer->getId());
-            $this->assertEquals(true, $deletedSelfMailer->getDeleted());
-        } catch (Exception $deleteError) {
-            echo 'Caught exception: ',  $deleteError->getMessage(), "\n";
-        }
-    }
+//     public function testList200()
+//     {
+//         $nextUrl = "";
+//         $previousUrl = "";
+//         $sfm1 = self::$selfMailersApi->create(self::$editableSelfMailer);
+//         $sfm2 = self::$selfMailersApi->create(self::$editableSelfMailer2);
+//         $listedSelfMailers = self::$selfMailersApi->list(2);
+//         $this->assertGreaterThan(1, count($listedSelfMailers->getData()));
+//         $this->assertLessThanOrEqual(2, count($listedSelfMailers->getData()));
+//         $nextUrl = substr($listedSelfMailers->getNextUrl(), strrpos($listedSelfMailers->getNextUrl(), "after=") + 6);
+//         $this->assertIsString($nextUrl);
+//         array_push($this->idsForCleanup, $sfm1->getId());
+//         array_push($this->idsForCleanup, $sfm2->getId());
 
-    public function testDelete404()
-    {
-        try {
-            $this->expectException(ApiException::class);
-            $this->expectExceptionMessageMatches("/self mailer not found/");
-            $badDeletion = self::$selfMailersApi->delete("sfm_NONEXISTENT");
-        } catch (Exception $retrieveError) {
-            echo 'Caught exception: ',  $retrieveError->getMessage(), "\n";
-        }
-    }
-}
+//         // response using nextUrl
+//         if ($nextUrl != "") {
+//             $sfm1 = self::$selfMailersApi->create(self::$editableSelfMailer);
+//             $sfm2 = self::$selfMailersApi->create(self::$editableSelfMailer2);
+//             $listedSelfMailersAfter = self::$selfMailersApi->list(2, null, $nextUrl);
+//             $this->assertGreaterThan(1, count($listedSelfMailersAfter->getData()));
+//             $this->assertLessThanOrEqual(2, count($listedSelfMailersAfter->getData()));
+//             $previousUrl = substr($listedSelfMailersAfter->getPreviousUrl(), strrpos($listedSelfMailersAfter->getPreviousUrl(), "before=") + 7);
+//             $this->assertIsString($previousUrl);
+//             array_push($this->idsForCleanup, $sfm1->getId());
+//             array_push($this->idsForCleanup, $sfm2->getId());
+//         }
+
+//         // response using previousUrl
+//         if ($previousUrl != "") {
+//             $sfm1 = self::$selfMailersApi->create(self::$editableSelfMailer);
+//             $sfm2 = self::$selfMailersApi->create(self::$editableSelfMailer2);
+//             $listedSelfMailersBefore = self::$selfMailersApi->list(2, $previousUrl);
+//             $this->assertGreaterThan(1, count($listedSelfMailersBefore->getData()));
+//             $this->assertLessThanOrEqual(2, count($listedSelfMailersBefore->getData()));
+//             array_push($this->idsForCleanup, $sfm1->getId());
+//             array_push($this->idsForCleanup, $sfm2->getId());
+//         }
+//     }
+
+//     public function provider()
+//     {
+//         return array(
+//             // array(null, null, null, array("total_count"), null, null, null, null, null, null, null), // include
+//             // array(null, null, null, null, array("gt" => (string)(date("c")), "lt" => (string)(date("c", time() + 86400))), null, null, null, null, null, null), // date_created
+//             array(null, null, null, null, null, self::$metadata, null, null, null, null, null), // metadata
+//             // array(null, null, null, null, null, null, [SelfMailerSize::_6X18_BIFOLD->value], null, null, null, null), // size
+//             // array(null, null, null, null, null, null, null, TRUE, null, null, null), // scheduled
+//             // array(null, null, null, null, null, null, null, null, array("gt" => (string)(date("c")), "lt" => (string)(date("c", time() + 86400))), null, null), // send_date
+//             array(null, null, null, null, null, null, null, null, null, MailType::FIRST_CLASS->value, null), // mail_type
+//             array(null, null, null, null, null, null, null, null, null, null, new SortBy5(array("date_created" => "asc"))) // sort_by
+//         );
+//     }
+
+//     /**
+//      * @dataProvider provider
+//      */
+//     public function testListWithParams($limit, $before, $after, $include, $date_created, $metadata, $size, $scheduled, $send_date, $mail_type, $sort_by)
+//     {
+//         // create self mailers to list
+//         $sfm1 = self::$selfMailersApi->create(self::$editableSelfMailer);
+//         $sfm2 = self::$selfMailersApi->create(self::$editableSelfMailer2);
+//         $listedSelfMailers = self::$selfMailersApi->list($limit, $before, $after, $include, $date_created, $metadata, $size, $scheduled, $send_date, $mail_type, $sort_by);
+
+//         $this->assertGreaterThan(0, $listedSelfMailers->getCount());
+//         if ($include) $this->assertNotNull($listedSelfMailers->getTotalCount());
+
+//         // delete created self mailers
+//         array_push($this->idsForCleanup, $sfm1->getId());
+//         array_push($this->idsForCleanup, $sfm2->getId());
+//     }
+
+//     public function testDelete200()
+//     {
+//         $createdSelfMailer = self::$selfMailersApi->create(self::$editableSelfMailer);
+//         $deletedSelfMailer = self::$selfMailersApi->delete($createdSelfMailer->getId());
+//         $this->assertEquals(true, $deletedSelfMailer->getDeleted());
+//     }
+
+//     public function testDelete401()
+//     {
+//         $createdSelfMailer = self::$selfMailersApi->create(self::$editableSelfMailer);
+//         array_push($this->idsForCleanup, $createdSelfMailer->getId());
+
+//         $this->expectException(ApiException::class);
+//         $this->expectExceptionMessageMatches("/Your API key is not valid. Please sign up on lob.com to get a valid api key./");
+//         $deletedSelfMailer = self::$invalidSelfMailerApi->delete($createdSelfMailer->getId());
+//     }
+
+//     public function testDelete404()
+//     {
+//         $this->expectException(ApiException::class);
+//         $this->expectExceptionMessageMatches("/self mailer not found/");
+//         $badDeletion = self::$selfMailersApi->delete("sfm_NONEXISTENT");
+//     }
+// }

--- a/test/Integration/SelfMailersApiSpecTest.php
+++ b/test/Integration/SelfMailersApiSpecTest.php
@@ -263,13 +263,17 @@ class SelfMailersApiSpecTest extends TestCase
 
     public function provider()
     {
+        date_default_timezone_set('America/Los_Angeles');
+        $date_str = date("Y-m-d", strtotime("-1 months"));
+        $date_obj = (object) array("gt" => $date_str);
+
         return array(
-            // array(null, null, null, array("total_count"), null, null, null, null, null, null, null), // include
-            // array(null, null, null, null, array("gt" => (string)(date("c")), "lt" => (string)(date("c", time() + 86400))), null, null, null, null, null, null), // date_created
+            array(null, null, null, array("total_count"), null, null, null, null, null, null, null), // include
+            array(null, null, null, null, $date_obj, null, null, null, null, null, null), // date_created
             array(null, null, null, null, null, self::$metadata, null, null, null, null, null), // metadata
-            // array(null, null, null, null, null, null, [SelfMailerSize::_6X18_BIFOLD->value], null, null, null, null), // size
-            // array(null, null, null, null, null, null, null, TRUE, null, null, null), // scheduled
-            // array(null, null, null, null, null, null, null, null, array("gt" => (string)(date("c")), "lt" => (string)(date("c", time() + 86400))), null, null), // send_date
+            array(null, null, null, null, null, null, [SelfMailerSize::_6X18_BIFOLD->value], null, null, null, null), // size
+            array(null, null, null, null, null, null, null, TRUE, null, null, null), // scheduled
+            array(null, null, null, null, null, null, null, null, $date_obj, null, null), // send_date
             array(null, null, null, null, null, null, null, null, null, MailType::FIRST_CLASS->value, null), // mail_type
             array(null, null, null, null, null, null, null, null, null, null, new SortBy5(array("date_created" => "asc"))) // sort_by
         );

--- a/test/Integration/TemplateVersionsApiSpecTest.php
+++ b/test/Integration/TemplateVersionsApiSpecTest.php
@@ -112,15 +112,23 @@ class TemplateVersionsApiSpecTest extends TestCase
     }
 
     public function testTemplateVersionsApiInstantiation200() {
-        $templateVersionsApi200 = new TemplateVersionsApi(self::$config);
-        $this->assertEquals(gettype($templateVersionsApi200), 'object');
+        try {
+            $templateVersionsApi200 = new TemplateVersionsApi(self::$config);
+            $this->assertEquals(gettype($templateVersionsApi200), 'object');
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+        }
     }
 
     public function testCreate200()
     {
-        $createdTemplateVersion = self::$templateVersionsApi->create(self::$tmplId, self::$writableTemplateVersion);
-        $this->assertMatchesRegularExpression('/vrsn_/', $createdTemplateVersion->getId());
-        array_push($this->idsForCleanup, $createdTemplateVersion->getId());
+        try {
+            $createdTemplateVersion = self::$templateVersionsApi->create(self::$tmplId, self::$writableTemplateVersion);
+            $this->assertMatchesRegularExpression('/vrsn_/', $createdTemplateVersion->getId());
+            array_push($this->idsForCleanup, $createdTemplateVersion->getId());
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+        }
     }
 
     // does not include required field in request
@@ -144,10 +152,14 @@ class TemplateVersionsApiSpecTest extends TestCase
 
     public function testGet200()
     {
-        $createdTemplateVersion = self::$templateVersionsApi->create(self::$tmplId, self::$writableTemplateVersion);
-        $retrievedTemplateVersion = self::$templateVersionsApi->get(self::$tmplId, $createdTemplateVersion->getId());
-        $this->assertEquals($createdTemplateVersion->getDescription(), $retrievedTemplateVersion->getDescription());
-        array_push($this->idsForCleanup, $createdTemplateVersion->getId());
+        try {
+            $createdTemplateVersion = self::$templateVersionsApi->create(self::$tmplId, self::$writableTemplateVersion);
+            $retrievedTemplateVersion = self::$templateVersionsApi->get(self::$tmplId, $createdTemplateVersion->getId());
+            $this->assertEquals($createdTemplateVersion->getDescription(), $retrievedTemplateVersion->getDescription());
+            array_push($this->idsForCleanup, $createdTemplateVersion->getId());
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+        }
     }
 
     public function testGet0()
@@ -176,12 +188,16 @@ class TemplateVersionsApiSpecTest extends TestCase
 
     public function testUpdate200()
     {
-        $templateVersionUpdate = new TemplateVersionUpdatable();
-        $templateVersionUpdate->setDescription("Updated Template");
-        $createdTemplateVersion = self::$templateVersionsApi->create(self::$tmplId, self::$writableTemplateVersion);
-        $retrievedTemplateVersion = self::$templateVersionsApi->update(self::$tmplId, $createdTemplateVersion->getId(), $templateVersionUpdate);
-        $this->assertEquals("Updated Template", $retrievedTemplateVersion->getDescription());
-        array_push($this->idsForCleanup, $createdTemplateVersion->getId());
+        try {
+            $templateVersionUpdate = new TemplateVersionUpdatable();
+            $templateVersionUpdate->setDescription("Updated Template");
+            $createdTemplateVersion = self::$templateVersionsApi->create(self::$tmplId, self::$writableTemplateVersion);
+            $retrievedTemplateVersion = self::$templateVersionsApi->update(self::$tmplId, $createdTemplateVersion->getId(), $templateVersionUpdate);
+            $this->assertEquals("Updated Template", $retrievedTemplateVersion->getDescription());
+            array_push($this->idsForCleanup, $createdTemplateVersion->getId());
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+        }
     }
 
     public function testUpdate0()
@@ -217,44 +233,56 @@ class TemplateVersionsApiSpecTest extends TestCase
     {
         $nextUrl = "";
         $previousUrl = "";
-        $tv1 = self::$templateVersionsApi->create(self::$tmplId, self::$templateVersion1);
-        $tv2 = self::$templateVersionsApi->create(self::$tmplId, self::$templateVersion2);
-        $tv3 = self::$templateVersionsApi->create(self::$tmplId, self::$templateVersion3);
-        $listedTemplateVersions = self::$templateVersionsApi->list(self::$tmplId, 3);
-        $this->assertGreaterThan(1, count($listedTemplateVersions->getData()));
-        $this->assertLessThanOrEqual(3, count($listedTemplateVersions->getData()));
-        $nextUrl = substr($listedTemplateVersions->getNextUrl(), strrpos($listedTemplateVersions->getNextUrl(), "after=") + 6);
-        $this->assertIsString($nextUrl);
-        array_push($this->idsForCleanup, $tv1->getId());
-        array_push($this->idsForCleanup, $tv2->getId());
-        array_push($this->idsForCleanup, $tv3->getId());
-
-        // response using nextUrl
-        if ($nextUrl != "") {
+        try {
             $tv1 = self::$templateVersionsApi->create(self::$tmplId, self::$templateVersion1);
             $tv2 = self::$templateVersionsApi->create(self::$tmplId, self::$templateVersion2);
             $tv3 = self::$templateVersionsApi->create(self::$tmplId, self::$templateVersion3);
-            $listedTemplateVersionsAfter = self::$templateVersionsApi->list(self::$tmplId, 3, null, $nextUrl);
-            $this->assertGreaterThanOrEqual(1, count($listedTemplateVersionsAfter->getData()));
-            $this->assertLessThanOrEqual(3, count($listedTemplateVersionsAfter->getData()));
-            $previousUrl = substr($listedTemplateVersionsAfter->getPreviousUrl(), strrpos($listedTemplateVersionsAfter->getPreviousUrl(), "before=") + 7);
-            $this->assertIsString($previousUrl);
+            $listedTemplateVersions = self::$templateVersionsApi->list(self::$tmplId, 3);
+            $this->assertGreaterThan(1, count($listedTemplateVersions->getData()));
+            $this->assertLessThanOrEqual(3, count($listedTemplateVersions->getData()));
+            $nextUrl = substr($listedTemplateVersions->getNextUrl(), strrpos($listedTemplateVersions->getNextUrl(), "after=") + 6);
+            $this->assertIsString($nextUrl);
             array_push($this->idsForCleanup, $tv1->getId());
             array_push($this->idsForCleanup, $tv2->getId());
             array_push($this->idsForCleanup, $tv3->getId());
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+        }
+
+        // response using nextUrl
+        if ($nextUrl != "") {
+            try {
+                $tv1 = self::$templateVersionsApi->create(self::$tmplId, self::$templateVersion1);
+                $tv2 = self::$templateVersionsApi->create(self::$tmplId, self::$templateVersion2);
+                $tv3 = self::$templateVersionsApi->create(self::$tmplId, self::$templateVersion3);
+                $listedTemplateVersionsAfter = self::$templateVersionsApi->list(self::$tmplId, 3, null, $nextUrl);
+                $this->assertGreaterThanOrEqual(1, count($listedTemplateVersionsAfter->getData()));
+                $this->assertLessThanOrEqual(3, count($listedTemplateVersionsAfter->getData()));
+                $previousUrl = substr($listedTemplateVersionsAfter->getPreviousUrl(), strrpos($listedTemplateVersionsAfter->getPreviousUrl(), "before=") + 7);
+                $this->assertIsString($previousUrl);
+                array_push($this->idsForCleanup, $tv1->getId());
+                array_push($this->idsForCleanup, $tv2->getId());
+                array_push($this->idsForCleanup, $tv3->getId());
+            } catch (\Exception $e) {
+                throw new \Exception($e->getMessage());
+            }
         }
 
         // response using previousUrl
         if ($previousUrl != "") {
-            $tv1 = self::$templateVersionsApi->create(self::$tmplId, self::$templateVersion1);
-            $tv2 = self::$templateVersionsApi->create(self::$tmplId, self::$templateVersion2);
-            $tv3 = self::$templateVersionsApi->create(self::$tmplId, self::$templateVersion3);
-            $listedTemplateVersionsBefore = self::$templateVersionsApi->list(self::$tmplId, 3, $previousUrl);
-            $this->assertGreaterThan(1, count($listedTemplateVersionsBefore->getData()));
-            $this->assertLessThanOrEqual(3, count($listedTemplateVersionsBefore->getData()));
-            array_push($this->idsForCleanup, $tv1->getId());
-            array_push($this->idsForCleanup, $tv2->getId());
-            array_push($this->idsForCleanup, $tv3->getId());
+            try {
+                $tv1 = self::$templateVersionsApi->create(self::$tmplId, self::$templateVersion1);
+                $tv2 = self::$templateVersionsApi->create(self::$tmplId, self::$templateVersion2);
+                $tv3 = self::$templateVersionsApi->create(self::$tmplId, self::$templateVersion3);
+                $listedTemplateVersionsBefore = self::$templateVersionsApi->list(self::$tmplId, 3, $previousUrl);
+                $this->assertGreaterThan(1, count($listedTemplateVersionsBefore->getData()));
+                $this->assertLessThanOrEqual(3, count($listedTemplateVersionsBefore->getData()));
+                array_push($this->idsForCleanup, $tv1->getId());
+                array_push($this->idsForCleanup, $tv2->getId());
+                array_push($this->idsForCleanup, $tv3->getId());
+            } catch (\Exception $e) {
+                throw new \Exception($e->getMessage());
+            }
         }
     }
 
@@ -275,28 +303,36 @@ class TemplateVersionsApiSpecTest extends TestCase
      */
     public function testListWithParams($limit, $before, $after, $include, $date_created)
     {
-        // create template versions to list
-        $tv1 = self::$templateVersionsApi->create(self::$tmplId, self::$templateVersion1);
-        $tv2 = self::$templateVersionsApi->create(self::$tmplId, self::$templateVersion2);
-        $tv3 = self::$templateVersionsApi->create(self::$tmplId, self::$templateVersion3);
+        try {
+            // create template versions to list
+            $tv1 = self::$templateVersionsApi->create(self::$tmplId, self::$templateVersion1);
+            $tv2 = self::$templateVersionsApi->create(self::$tmplId, self::$templateVersion2);
+            $tv3 = self::$templateVersionsApi->create(self::$tmplId, self::$templateVersion3);
 
-        // cancel created template versions
-        array_push($this->idsForCleanup, $tv1->getId());
-        array_push($this->idsForCleanup, $tv2->getId());
-        array_push($this->idsForCleanup, $tv3->getId());
+            // cancel created template versions
+            array_push($this->idsForCleanup, $tv1->getId());
+            array_push($this->idsForCleanup, $tv2->getId());
+            array_push($this->idsForCleanup, $tv3->getId());
 
-        $listedTemplateVersions = self::$templateVersionsApi->list(self::$tmplId, $limit, $before, $after, $include, $date_created);
+            $listedTemplateVersions = self::$templateVersionsApi->list(self::$tmplId, $limit, $before, $after, $include, $date_created);
 
-        $this->assertGreaterThan(0, $listedTemplateVersions->getCount());
-        if ($include) $this->assertNotNull($listedTemplateVersions->getTotalCount());
+            $this->assertGreaterThan(0, $listedTemplateVersions->getCount());
+            if ($include) $this->assertNotNull($listedTemplateVersions->getTotalCount());
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+        }
     }
 
     public function testDelete200()
     {
-        $createdTemplateVersion = self::$templateVersionsApi->create(self::$tmplId, self::$writableTemplateVersion);
-        $deletedTemplateVersion = self::$templateVersionsApi->delete(self::$tmplId, $createdTemplateVersion->getId());
-        $this->assertEquals(true, $deletedTemplateVersion->getDeleted());
-        $this->assertMatchesRegularExpression('/vrsn_/', $deletedTemplateVersion->getId());
+        try {
+            $createdTemplateVersion = self::$templateVersionsApi->create(self::$tmplId, self::$writableTemplateVersion);
+            $deletedTemplateVersion = self::$templateVersionsApi->delete(self::$tmplId, $createdTemplateVersion->getId());
+            $this->assertEquals(true, $deletedTemplateVersion->getDeleted());
+            $this->assertMatchesRegularExpression('/vrsn_/', $deletedTemplateVersion->getId());
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+        }
     }
 
     public function testDelete401()

--- a/test/Integration/TemplatesApiSpecTest.php
+++ b/test/Integration/TemplatesApiSpecTest.php
@@ -251,9 +251,13 @@ class TemplatesApiSpecTest extends TestCase
 
     public function provider()
     {
+        date_default_timezone_set('America/Los_Angeles');
+        $date_str = date("Y-m-d", strtotime("-1 months"));
+        $date_obj = (object) array("gt" => $date_str);
+
         return array(
-            // array(null, null, null, array("total_count"), null, null), // include
-            // array(null, null, null, null, array("gt" => (string)(date("c")), "lt" => (string)(date("c", time() + 86400))), null), // date_created
+            array(null, null, null, array("total_count"), null, null), // include
+            array(null, null, null, null, $date_obj, null), // date_created
             array(null, null, null, null, null, self::$metadata), // metadata
         );
     }
@@ -278,7 +282,6 @@ class TemplatesApiSpecTest extends TestCase
         $this->assertGreaterThan(0, $listedTemplates->getCount());
         if ($include) $this->assertNotNull($listedTemplates->getTotalCount());
     }
-
 
     public function testDelete200()
     {

--- a/test/Integration/TemplatesApiSpecTest.php
+++ b/test/Integration/TemplatesApiSpecTest.php
@@ -105,15 +105,23 @@ class TemplatesApiSpecTest extends TestCase
     }
 
     public function testTemplatesApiInstantiation200() {
-        $templateApi200 = new TemplatesApi(self::$config);
-        $this->assertEquals(gettype($templateApi200), 'object');
+        try {
+            $templateApi200 = new TemplatesApi(self::$config);
+            $this->assertEquals(gettype($templateApi200), 'object');
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+        }
     }
 
     public function testCreate200()
     {
-        $createdTemplate = self::$templateApi->create(self::$writableTemplate);
-        $this->assertMatchesRegularExpression('/tmpl_/', $createdTemplate->getId());
-        array_push($this->idsForCleanup, $createdTemplate->getId());
+        try {
+            $createdTemplate = self::$templateApi->create(self::$writableTemplate);
+            $this->assertMatchesRegularExpression('/tmpl_/', $createdTemplate->getId());
+            array_push($this->idsForCleanup, $createdTemplate->getId());
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+        }
     }
 
     // does not include required field in request
@@ -137,10 +145,14 @@ class TemplatesApiSpecTest extends TestCase
 
     public function testGet200()
     {
-        $createdTemplate = self::$templateApi->create(self::$writableTemplate);
-        $retrievedTemplate = self::$templateApi->get($createdTemplate->getId());
-        $this->assertEquals($createdTemplate->getDescription(), $retrievedTemplate->getDescription());
-        array_push($this->idsForCleanup, $createdTemplate->getId());
+        try {
+            $createdTemplate = self::$templateApi->create(self::$writableTemplate);
+            $retrievedTemplate = self::$templateApi->get($createdTemplate->getId());
+            $this->assertEquals($createdTemplate->getDescription(), $retrievedTemplate->getDescription());
+            array_push($this->idsForCleanup, $createdTemplate->getId());
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+        }
     }
 
     public function testGet0()
@@ -169,12 +181,16 @@ class TemplatesApiSpecTest extends TestCase
 
     public function testUpdate200()
     {
-        $templateUpdate = new TemplateUpdate();
-        $templateUpdate->setDescription("Updated Template");
-        $createdTemplate = self::$templateApi->create(self::$writableTemplate);
-        $retrievedTemplate = self::$templateApi->update($createdTemplate->getId(), $templateUpdate);
-        $this->assertEquals("Updated Template", $retrievedTemplate->getDescription());
-        array_push($this->idsForCleanup, $createdTemplate->getId());
+        try {
+            $templateUpdate = new TemplateUpdate();
+            $templateUpdate->setDescription("Updated Template");
+            $createdTemplate = self::$templateApi->create(self::$writableTemplate);
+            $retrievedTemplate = self::$templateApi->update($createdTemplate->getId(), $templateUpdate);
+            $this->assertEquals("Updated Template", $retrievedTemplate->getDescription());
+            array_push($this->idsForCleanup, $createdTemplate->getId());
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+        }
     }
 
     public function testUpdate0()
@@ -208,44 +224,56 @@ class TemplatesApiSpecTest extends TestCase
     {
         $nextUrl = "";
         $previousUrl = "";
-        $tmpl1 = self::$templateApi->create(self::$template1);
-        $tmpl2 = self::$templateApi->create(self::$template2);
-        $tmpl3 = self::$templateApi->create(self::$template3);
-        $listedTemplates = self::$templateApi->list(3);
-        $this->assertGreaterThan(1, count($listedTemplates->getData()));
-        $this->assertLessThanOrEqual(3, count($listedTemplates->getData()));
-        $nextUrl = substr($listedTemplates->getNextUrl(), strrpos($listedTemplates->getNextUrl(), "after=") + 6);
-        $this->assertIsString($nextUrl);
-        array_push($this->idsForCleanup, $tmpl1->getId());
-        array_push($this->idsForCleanup, $tmpl2->getId());
-        array_push($this->idsForCleanup, $tmpl3->getId());
-
-        // response using nextUrl
-        if ($nextUrl != "") {
+        try {
             $tmpl1 = self::$templateApi->create(self::$template1);
             $tmpl2 = self::$templateApi->create(self::$template2);
             $tmpl3 = self::$templateApi->create(self::$template3);
-            $listedTemplatesAfter = self::$templateApi->list(3, null, $nextUrl);
-            $this->assertGreaterThan(1, count($listedTemplatesAfter->getData()));
-            $this->assertLessThanOrEqual(3, count($listedTemplatesAfter->getData()));
-            $previousUrl = substr($listedTemplatesAfter->getPreviousUrl(), strrpos($listedTemplatesAfter->getPreviousUrl(), "before=") + 7);
-            $this->assertIsString($previousUrl);
+            $listedTemplates = self::$templateApi->list(3);
+            $this->assertGreaterThan(1, count($listedTemplates->getData()));
+            $this->assertLessThanOrEqual(3, count($listedTemplates->getData()));
+            $nextUrl = substr($listedTemplates->getNextUrl(), strrpos($listedTemplates->getNextUrl(), "after=") + 6);
+            $this->assertIsString($nextUrl);
             array_push($this->idsForCleanup, $tmpl1->getId());
             array_push($this->idsForCleanup, $tmpl2->getId());
             array_push($this->idsForCleanup, $tmpl3->getId());
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+        }
+
+        // response using nextUrl
+        if ($nextUrl != "") {
+            try {
+                $tmpl1 = self::$templateApi->create(self::$template1);
+                $tmpl2 = self::$templateApi->create(self::$template2);
+                $tmpl3 = self::$templateApi->create(self::$template3);
+                $listedTemplatesAfter = self::$templateApi->list(3, null, $nextUrl);
+                $this->assertGreaterThan(1, count($listedTemplatesAfter->getData()));
+                $this->assertLessThanOrEqual(3, count($listedTemplatesAfter->getData()));
+                $previousUrl = substr($listedTemplatesAfter->getPreviousUrl(), strrpos($listedTemplatesAfter->getPreviousUrl(), "before=") + 7);
+                $this->assertIsString($previousUrl);
+                array_push($this->idsForCleanup, $tmpl1->getId());
+                array_push($this->idsForCleanup, $tmpl2->getId());
+                array_push($this->idsForCleanup, $tmpl3->getId());
+            } catch (\Exception $e) {
+                throw new \Exception($e->getMessage());
+            }
         }
 
         // response using previousUrl
         if ($previousUrl != "") {
-            $tmpl1 = self::$templateApi->create(self::$template1);
-            $tmpl2 = self::$templateApi->create(self::$template2);
-            $tmpl3 = self::$templateApi->create(self::$template3);
-            $listedTemplatesBefore = self::$templateApi->list(3, $previousUrl);
-            $this->assertGreaterThan(1, count($listedTemplatesBefore->getData()));
-            $this->assertLessThanOrEqual(3, count($listedTemplatesBefore->getData()));
-            array_push($this->idsForCleanup, $tmpl1->getId());
-            array_push($this->idsForCleanup, $tmpl2->getId());
-            array_push($this->idsForCleanup, $tmpl3->getId());
+            try {
+                $tmpl1 = self::$templateApi->create(self::$template1);
+                $tmpl2 = self::$templateApi->create(self::$template2);
+                $tmpl3 = self::$templateApi->create(self::$template3);
+                $listedTemplatesBefore = self::$templateApi->list(3, $previousUrl);
+                $this->assertGreaterThan(1, count($listedTemplatesBefore->getData()));
+                $this->assertLessThanOrEqual(3, count($listedTemplatesBefore->getData()));
+                array_push($this->idsForCleanup, $tmpl1->getId());
+                array_push($this->idsForCleanup, $tmpl2->getId());
+                array_push($this->idsForCleanup, $tmpl3->getId());
+            } catch (\Exception $e) {
+                throw new \Exception($e->getMessage());
+            }
         }
     }
 
@@ -267,28 +295,36 @@ class TemplatesApiSpecTest extends TestCase
      */
     public function testListWithParams($limit, $before, $after, $include, $date_created, $metadata)
     {
-        // create templates to list
-        $tmpl1 = self::$templateApi->create(self::$template1);
-        $tmpl2 = self::$templateApi->create(self::$template2);
-        $tmpl3 = self::$templateApi->create(self::$template3);
+        try {
+            // create templates to list
+            $tmpl1 = self::$templateApi->create(self::$template1);
+            $tmpl2 = self::$templateApi->create(self::$template2);
+            $tmpl3 = self::$templateApi->create(self::$template3);
 
-        // cancel created templates
-        array_push($this->idsForCleanup, $tmpl1->getId());
-        array_push($this->idsForCleanup, $tmpl2->getId());
-        array_push($this->idsForCleanup, $tmpl3->getId());
+            // cancel created templates
+            array_push($this->idsForCleanup, $tmpl1->getId());
+            array_push($this->idsForCleanup, $tmpl2->getId());
+            array_push($this->idsForCleanup, $tmpl3->getId());
 
-        $listedTemplates = self::$templateApi->list($limit, $before, $after, $include, $date_created, $metadata);
+            $listedTemplates = self::$templateApi->list($limit, $before, $after, $include, $date_created, $metadata);
 
-        $this->assertGreaterThan(0, $listedTemplates->getCount());
-        if ($include) $this->assertNotNull($listedTemplates->getTotalCount());
+            $this->assertGreaterThan(0, $listedTemplates->getCount());
+            if ($include) $this->assertNotNull($listedTemplates->getTotalCount());
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+        }
     }
 
     public function testDelete200()
     {
-        $createdTemplate = self::$templateApi->create(self::$writableTemplate);
-        $deletedTemplate = self::$templateApi->delete($createdTemplate->getId());
-        $this->assertEquals(true, $deletedTemplate->getDeleted());
-        $this->assertMatchesRegularExpression('/tmpl_/', $deletedTemplate->getId());
+        try {
+            $createdTemplate = self::$templateApi->create(self::$writableTemplate);
+            $deletedTemplate = self::$templateApi->delete($createdTemplate->getId());
+            $this->assertEquals(true, $deletedTemplate->getDeleted());
+            $this->assertMatchesRegularExpression('/tmpl_/', $deletedTemplate->getId());
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+        }
     }
 
     public function testDelete401()

--- a/test/Integration/UsAutocompletionsApiSpecTest.php
+++ b/test/Integration/UsAutocompletionsApiSpecTest.php
@@ -70,30 +70,42 @@ class UsAutocompletionsApiSpecTest extends TestCase
     }
 
     public function testUsAutocompletionsApiInstantiation200() {
-        $usAutocompletionApi = new UsAutocompletionsApi(self::$config);
-        $this->assertEquals(gettype($usAutocompletionApi), "object");
+        try {
+            $usAutocompletionApi = new UsAutocompletionsApi(self::$config);
+            $this->assertEquals(gettype($usAutocompletionApi), "object");
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+        }
     }
 
     public function testUsAutocompletion()
     {
-        $usAutocompletionObject = self::$usAutocompletionApi->autocomplete(self::$autocompletionWritable);
-        $this->assertMatchesRegularExpression("/us_auto_/", $usAutocompletionObject->getId());
-        $this->assertGreaterThan(0, count($usAutocompletionObject->getSuggestions()));
+        try {
+            $usAutocompletionObject = self::$usAutocompletionApi->autocomplete(self::$autocompletionWritable);
+            $this->assertMatchesRegularExpression("/us_auto_/", $usAutocompletionObject->getId());
+            $this->assertGreaterThan(0, count($usAutocompletionObject->getSuggestions()));
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+        }
     }
 
     public function testUsAutocompletionTestKey()
     {
-        $testAutocompletion = new UsAutocompletionsWritable();
-        $testAutocompletion->setAddressPrefix("1313 T");
-        $testAutocompletion->setState("NJ");
-        $testAutocompletion->setGeoIpSort(false);
+        try {
+            $testAutocompletion = new UsAutocompletionsWritable();
+            $testAutocompletion->setAddressPrefix("1313 T");
+            $testAutocompletion->setState("NJ");
+            $testAutocompletion->setGeoIpSort(false);
 
-        $wrongConfig = new Configuration();
-        $wrongConfig->setApiKey("basic", getenv("LOB_API_TEST_KEY"));
-        $autocompletionApiError = new UsAutocompletionsApi($wrongConfig);
+            $wrongConfig = new Configuration();
+            $wrongConfig->setApiKey("basic", getenv("LOB_API_TEST_KEY"));
+            $autocompletionApiError = new UsAutocompletionsApi($wrongConfig);
 
-        $usAutocompletionObject = $autocompletionApiError->autocomplete($testAutocompletion);
-        $this->assertEquals("TEST KEYS DO NOT AUTOCOMPLETE US ADDRESSES", $usAutocompletionObject->getSuggestions()[0]->getPrimaryLine());
+            $usAutocompletionObject = $autocompletionApiError->autocomplete($testAutocompletion);
+            $this->assertEquals("TEST KEYS DO NOT AUTOCOMPLETE US ADDRESSES", $usAutocompletionObject->getSuggestions()[0]->getPrimaryLine());
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+        }
     }
 
     public function testUsAutocompletion0()

--- a/test/Integration/UsVerificationsApiSpecTest.php
+++ b/test/Integration/UsVerificationsApiSpecTest.php
@@ -51,6 +51,7 @@ class UsVerificationsApiSpecTest extends TestCase
      */
     private static $config;
     private static $usvApi200;
+    private static $invalidUsvApi;
     private static $validAddress1;
     private static $validAddress2;
     private static $multipleAddressList;
@@ -61,8 +62,12 @@ class UsVerificationsApiSpecTest extends TestCase
     {
         // create instance of UsVerificationsApiSpecTest & an editable address for other tests
         self::$config = new Configuration();
-        self::$config->setApiKey('basic', getenv('LOB_API_LIVE_KEY'));
+        self::$config->setApiKey("basic", getenv("LOB_API_LIVE_KEY"));
         self::$usvApi200 = new UsVerificationsApi(self::$config);
+
+        $wrongConfig = new Configuration();
+        $wrongConfig->setApiKey("basic", "BAD KEY");
+        self::$invalidUsvApi = new UsVerificationsApi($wrongConfig);
 
         self::$validAddress1 = new UsVerificationsWritable();
         self::$validAddress1->setPrimaryLine("210 KING ST");
@@ -102,75 +107,82 @@ class UsVerificationsApiSpecTest extends TestCase
     }
 
     public function testUsVerificationsApiInstantiation200() {
-        try {
-            $usvApi200 = new UsVerificationsApi(self::$config);
-            $this->assertEquals(gettype($usvApi200), 'object');
-        } catch (Exception $instantiationError) {
-            echo 'Caught exception: ',  $instantiationError->getMessage(), "\n";
-        }
+        $usvApi200 = new UsVerificationsApi(self::$config);
+        $this->assertEquals(gettype($usvApi200), "object");
     }
 
     public function testSingleUsVerificationDeliverable()
     {
-        try {
-            $usVerificationObject = self::$usvApi200->verifySingle(self::$validAddress1);
-            $this->assertMatchesRegularExpression('/us_ver_/', $usVerificationObject->getId());
-            $this->assertEquals('deliverable', $usVerificationObject->getDeliverability());
-        } catch (Exception $createError) {
-            echo 'Caught exception: ',  $createError->getMessage(), "\n";
-        }
+        $usVerificationObject = self::$usvApi200->verifySingle(self::$validAddress1);
+        $this->assertMatchesRegularExpression("/us_ver_/", $usVerificationObject->getId());
+        $this->assertEquals("deliverable", $usVerificationObject->getDeliverability());
     }
 
     public function testSingleUsVerificationUndeliverable()
     {
-        try {
-            $usVerificationObject = self::$usvApi200->verifySingle(self::$undeliverableAddress);
-            $this->assertMatchesRegularExpression('/us_ver_/', $usVerificationObject->getId());
-            $this->assertEquals('undeliverable', $usVerificationObject->getDeliverability());
+        $usVerificationObject = self::$usvApi200->verifySingle(self::$undeliverableAddress);
+        $this->assertMatchesRegularExpression("/us_ver_/", $usVerificationObject->getId());
+        $this->assertEquals("undeliverable", $usVerificationObject->getDeliverability());
+    }
 
-        } catch (Exception $createError) {
-            echo 'Caught exception: ',  $createError->getMessage(), "\n";
-        }
+    public function testSingleUsVerification0()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches("/Missing the required parameter/");
+        $usVerificationObject = self::$usvApi200->verifySingle(null);
+    }
+
+    public function testSingleUsVerification401()
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessageMatches("/Your API key is not valid/");
+        $badVerification = self::$invalidUsvApi->verifySingle(self::$validAddress1);
     }
 
     public function testBulkUsVerificationValid()
     {
-        try {
-            $usVerificationObject = self::$usvApi200->verifyBulk(self::$multipleAddressList);
-            $this->assertGreaterThan(1, count($usVerificationObject->getAddresses()));
-            $this->assertEquals('deliverable', $usVerificationObject->getAddresses()[0]->getDeliverability());
-            $this->assertEquals('undeliverable', $usVerificationObject->getAddresses()[1]->getDeliverability());
-        } catch (Exception $createError) {
-            echo 'Caught exception: ',  $createError->getMessage(), "\n";
-        }
+        $usVerificationObject = self::$usvApi200->verifyBulk(self::$multipleAddressList);
+        $this->assertGreaterThan(1, count($usVerificationObject->getAddresses()));
+        $this->assertEquals("deliverable", $usVerificationObject->getAddresses()[0]->getDeliverability());
+        $this->assertEquals("undeliverable", $usVerificationObject->getAddresses()[1]->getDeliverability());
     }
 
     public function testBulkUsVerificationError()
     {
-        try {
-            $mc1 = new MultipleComponents();
-            $mc1->setPrimaryLine("210 KING ST");
-            $mc1->setCity("SAN FRANCISCO");
-            $mc1->setState("CA");
-            $mc1->setZipCode("94107");
-    
-            // second entry has no primary line, should error
-            $mc2 = new MultipleComponents();
-            $mc2->setSecondaryLine("SUITE 666");
-            $mc2->setCity("WESTFIELD");
-            $mc2->setState("NJ");
-            $mc2->setZipCode("07000");
-    
-            // multiple components list for bulk verification test
-            $errorAddressList = new MultipleComponentsList();
-            $errorAddressList->setAddresses([$mc1, $mc2]);
+        $mc1 = new MultipleComponents();
+        $mc1->setPrimaryLine("210 KING ST");
+        $mc1->setCity("SAN FRANCISCO");
+        $mc1->setState("CA");
+        $mc1->setZipCode("94107");
 
-            $errorVerificationObject = self::$usvApi200->verifyBulk($errorAddressList);
+        // second entry has no primary line, should error
+        $mc2 = new MultipleComponents();
+        $mc2->setSecondaryLine("SUITE 666");
+        $mc2->setCity("WESTFIELD");
+        $mc2->setState("NJ");
+        $mc2->setZipCode("07000");
 
-            $this->assertEquals('primary_line is required or address is required', $errorVerificationObject->getAddresses()[1]->getError()->getError()->getMessage());
-            $this->assertEquals(1, $errorVerificationObject->getErrors());
-        } catch (Exception $createError) {
-            echo 'Caught exception: ',  $createError->getMessage(), "\n";
-        }
+        // multiple components list for bulk verification test
+        $errorAddressList = new MultipleComponentsList();
+        $errorAddressList->setAddresses([$mc1, $mc2]);
+
+        $errorVerificationObject = self::$usvApi200->verifyBulk($errorAddressList);
+
+        $this->assertEquals("primary_line is required or address is required", $errorVerificationObject->getAddresses()[1]->getError()->getError()->getMessage());
+        $this->assertEquals(1, $errorVerificationObject->getErrors());
+    }
+
+    public function testBulkUsVerification0()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches("/Missing the required parameter/");
+        $usVerificationObject = self::$usvApi200->verifyBulk(null);
+    }
+
+    public function testBulkUsVerification401()
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessageMatches("/Your API key is not valid/");
+        $badVerification = self::$invalidUsvApi->verifyBulk(self::$multipleAddressList);
     }
 }

--- a/test/Integration/UsVerificationsApiSpecTest.php
+++ b/test/Integration/UsVerificationsApiSpecTest.php
@@ -107,22 +107,34 @@ class UsVerificationsApiSpecTest extends TestCase
     }
 
     public function testUsVerificationsApiInstantiation200() {
-        $usvApi200 = new UsVerificationsApi(self::$config);
-        $this->assertEquals(gettype($usvApi200), "object");
+        try {
+            $usvApi200 = new UsVerificationsApi(self::$config);
+            $this->assertEquals(gettype($usvApi200), "object");
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+        }
     }
 
     public function testSingleUsVerificationDeliverable()
     {
-        $usVerificationObject = self::$usvApi200->verifySingle(self::$validAddress1);
-        $this->assertMatchesRegularExpression("/us_ver_/", $usVerificationObject->getId());
-        $this->assertEquals("deliverable", $usVerificationObject->getDeliverability());
+        try {
+            $usVerificationObject = self::$usvApi200->verifySingle(self::$validAddress1);
+            $this->assertMatchesRegularExpression("/us_ver_/", $usVerificationObject->getId());
+            $this->assertEquals("deliverable", $usVerificationObject->getDeliverability());
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+        }
     }
 
     public function testSingleUsVerificationUndeliverable()
     {
+        try {
         $usVerificationObject = self::$usvApi200->verifySingle(self::$undeliverableAddress);
         $this->assertMatchesRegularExpression("/us_ver_/", $usVerificationObject->getId());
         $this->assertEquals("undeliverable", $usVerificationObject->getDeliverability());
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+        }
     }
 
     public function testSingleUsVerification0()
@@ -141,35 +153,43 @@ class UsVerificationsApiSpecTest extends TestCase
 
     public function testBulkUsVerificationValid()
     {
+        try {
         $usVerificationObject = self::$usvApi200->verifyBulk(self::$multipleAddressList);
         $this->assertGreaterThan(1, count($usVerificationObject->getAddresses()));
         $this->assertEquals("deliverable", $usVerificationObject->getAddresses()[0]->getDeliverability());
         $this->assertEquals("undeliverable", $usVerificationObject->getAddresses()[1]->getDeliverability());
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+        }
     }
 
     public function testBulkUsVerificationError()
     {
-        $mc1 = new MultipleComponents();
-        $mc1->setPrimaryLine("210 KING ST");
-        $mc1->setCity("SAN FRANCISCO");
-        $mc1->setState("CA");
-        $mc1->setZipCode("94107");
+        try {
+            $mc1 = new MultipleComponents();
+            $mc1->setPrimaryLine("210 KING ST");
+            $mc1->setCity("SAN FRANCISCO");
+            $mc1->setState("CA");
+            $mc1->setZipCode("94107");
 
-        // second entry has no primary line, should error
-        $mc2 = new MultipleComponents();
-        $mc2->setSecondaryLine("SUITE 666");
-        $mc2->setCity("WESTFIELD");
-        $mc2->setState("NJ");
-        $mc2->setZipCode("07000");
+            // second entry has no primary line, should error
+            $mc2 = new MultipleComponents();
+            $mc2->setSecondaryLine("SUITE 666");
+            $mc2->setCity("WESTFIELD");
+            $mc2->setState("NJ");
+            $mc2->setZipCode("07000");
 
-        // multiple components list for bulk verification test
-        $errorAddressList = new MultipleComponentsList();
-        $errorAddressList->setAddresses([$mc1, $mc2]);
+            // multiple components list for bulk verification test
+            $errorAddressList = new MultipleComponentsList();
+            $errorAddressList->setAddresses([$mc1, $mc2]);
 
-        $errorVerificationObject = self::$usvApi200->verifyBulk($errorAddressList);
+            $errorVerificationObject = self::$usvApi200->verifyBulk($errorAddressList);
 
-        $this->assertEquals("primary_line is required or address is required", $errorVerificationObject->getAddresses()[1]->getError()->getError()->getMessage());
-        $this->assertEquals(1, $errorVerificationObject->getErrors());
+            $this->assertEquals("primary_line is required or address is required", $errorVerificationObject->getAddresses()[1]->getError()->getError()->getMessage());
+            $this->assertEquals(1, $errorVerificationObject->getErrors());
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+        }
     }
 
     public function testBulkUsVerification0()

--- a/test/Integration/ZipLookupsApiSpecTest.php
+++ b/test/Integration/ZipLookupsApiSpecTest.php
@@ -63,28 +63,41 @@ class ZipLookupsApiSpecTest extends TestCase
     }
 
     public function testZipLookupsApiInstantiation200() {
-        try {
-            $zipApi = new ZipLookupsApi(self::$config);
-            $this->assertEquals(gettype($zipApi), 'object');
-        } catch (Exception $instantiationError) {
-            echo 'Caught exception: ',  $instantiationError->getMessage(), "\n";
-        }
+        $zipApi = new ZipLookupsApi(self::$config);
+        $this->assertEquals(gettype($zipApi), 'object');
     }
 
     public function testLookup()
     {
-        try {
-            $zipEditable = new ZipEditable();
-            $zipEditable->setZipCode("94107");
-            $zipObject = self::$zipApi->lookup($zipEditable);
-            $this->assertMatchesRegularExpression('/us_zip_/', $zipObject->getId());
-            $this->assertGreaterThanOrEqual(1, count($zipObject->getCities()));
-        } catch (Exception $createError) {
-            echo 'Caught exception: ',  $createError->getMessage(), "\n";
-        }
+        $zipEditable = new ZipEditable();
+        $zipEditable->setZipCode("94107");
+        $zipObject = self::$zipApi->lookup($zipEditable);
+        $this->assertMatchesRegularExpression('/us_zip_/', $zipObject->getId());
+        $this->assertGreaterThanOrEqual(1, count($zipObject->getCities()));
     }
 
-    public function testLookupError()
+    public function testLookup0()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches("/Missing the required parameter/");
+        $zipObject = self::$zipApi->lookup(null);
+    }
+
+    public function testLookup401()
+    {
+        $zipEditable = new ZipEditable();
+        $zipEditable->setZipCode("94107");
+
+        $wrongConfig = new Configuration();
+        $wrongConfig->setApiKey('basic', 'BAD KEY');
+        $invalidZipApi = new ZipLookupsApi($wrongConfig);
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessageMatches("/Your API key is not valid/");
+        $zipObject = $invalidZipApi->lookup($zipEditable);
+    }
+
+    public function testLookup422()
     {
         $zipEditable = new ZipEditable();
         $this->expectException(ApiException::class);

--- a/test/Integration/ZipLookupsApiSpecTest.php
+++ b/test/Integration/ZipLookupsApiSpecTest.php
@@ -63,17 +63,25 @@ class ZipLookupsApiSpecTest extends TestCase
     }
 
     public function testZipLookupsApiInstantiation200() {
-        $zipApi = new ZipLookupsApi(self::$config);
-        $this->assertEquals(gettype($zipApi), 'object');
+        try {
+            $zipApi = new ZipLookupsApi(self::$config);
+            $this->assertEquals(gettype($zipApi), 'object');
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+        }
     }
 
     public function testLookup()
     {
-        $zipEditable = new ZipEditable();
-        $zipEditable->setZipCode("94107");
-        $zipObject = self::$zipApi->lookup($zipEditable);
-        $this->assertMatchesRegularExpression('/us_zip_/', $zipObject->getId());
-        $this->assertGreaterThanOrEqual(1, count($zipObject->getCities()));
+        try {
+            $zipEditable = new ZipEditable();
+            $zipEditable->setZipCode("94107");
+            $zipObject = self::$zipApi->lookup($zipEditable);
+            $this->assertMatchesRegularExpression('/us_zip_/', $zipObject->getId());
+            $this->assertGreaterThanOrEqual(1, count($zipObject->getCities()));
+        } catch (\Exception $e) {
+            throw new \Exception($e->getMessage());
+        }
     }
 
     public function testLookup0()


### PR DESCRIPTION
[ticket](https://lobsters.atlassian.net/browse/DXP-1111)

Got rid of all the try catches because:
1. If the API does fail, don't we want it to break the tests rather than just print the errs?
2. The tests stop upon hitting an exception so nothing gets printed.

Done:
- [x] Addresses
- [x] BankAccounts
- [x] BillingGroups
  - problem with `include` param of List op
- [x] CardOrders
  - The retrieve op test was skipped presumably b/c `next_url` and `previous_url` are `null`. I don't think these are meant to have values though. The example response for this op in docs.lob.com has those fields set to `null`. And I believe the `offset` field serves the same purpose as next and prev url.
- [x] Cards
- [x] Checks
- [x] Letters
- [x] Postcards
- [x] ReverseGeocodeLookups
- [x] SelfMailers
- [x] TemplateVersions
- [x] Templates
- [x] UsAutocompletions
- [x] UsVerifications
- [x] ZipLookups