### PR TITLE
remove legacy docs link of old SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 [![Build Status](https://travis-ci.org/lob/lob-php.svg?branch=master)](https://travis-ci.org/lob/lob-php)
 [![Coverage Status](https://img.shields.io/coveralls/lob/lob-php.svg)](https://coveralls.io/r/lob/lob-php?branch=master)
 
-Lob.com PHP Client is a simple but flexible wrapper for the [Lob.com](https://www.lob.com) API. See full Lob.com documentation [here](https://lob.com/docs/php). For best results, be sure that you're using [the latest version](https://lob.com/docs/php#version) of the Lob API and the latest version of the PHP wrapper.
+Lob.com PHP Client is a simple but flexible wrapper for the [Lob.com](https://www.lob.com) API. The documentation for the legacy PHP SDK no longer exists, but documentation for the new PHP SDK can be found [here](https://docs.lob.com/). For best results, be sure that you're using [the latest version](https://lob.com/docs/php#version) of the Lob API and the latest version of the PHP wrapper.
 ******
 Starting a new project, we recommend using <a href="https://github.com/lob/lob-php"><strong>Version 4.0.0</strong></a>!
-    
+
 Moving your existing project from 3.0.0 to 4.0.0? <a href="https://github.com/lob/lob-php/blob/main/MIGRATION.md">Checkout this migration guide.</a>
 ******
 


### PR DESCRIPTION
## Description

Got rid of legacy docs link in README.

## Story

[JIRA-1228](https://lobsters.atlassian.net/browse/DXP-1228)

## Verify

- [x] Code runs without errors
- [x] Tests pass with >=85% line coverage
