### PR TITLE
Uppercase coverage value to pass validation

### DIFF
--- a/lib/Model/IntlVerification.php
+++ b/lib/Model/IntlVerification.php
@@ -617,20 +617,21 @@ class IntlVerification implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setCoverage($coverage)
     {
+        $normalizedCoverage = is_string($coverage) ? strtoupper($coverage) : null;
         $allowedValues = $this->getCoverageAllowableValues();
         if (!method_exists($this, 'getId') || (!empty($this->getId()) && strpos($this->getId(), "fakeId") === False)) {
-            if (!is_null($coverage) && !in_array($coverage, $allowedValues, true)) {
+            if (!is_null($normalizedCoverage) && !in_array($normalizedCoverage, $allowedValues, true)) {
                 throw new \InvalidArgumentException(
                     sprintf(
                         "Invalid value '%s' for 'coverage', must be one of '%s'",
-                        $coverage,
+                        $normalizedCoverage,
                         implode("', '", $allowedValues)
                     )
                 );
             }
         }
 
-        $this->container['coverage'] = $coverage;
+        $this->container['coverage'] = $normalizedCoverage;
 
         return $this;
     }


### PR DESCRIPTION
## Description

The PR partially solves #172 by fixing `coverage` value for `IntlVerification` object

Note, there is a similar issue with  `setStatus` but it's not possible to solve it in such an easy way, as a described in the issue:

>it's not possible to fix `\OpenAPI\Client\Model\IntlVerification::setStatus`  on this library level: when this method accept a numeric string (e.g. `1`), we don't how to properly prefix the string because there are few possible prefixes (`LV`, `LF`, `LM`, `LU`. see the screenshot above). So, the only solution is to fix server response or lose `IntlVerification` validation in `setCoverage` and `setStatus` methods 


So, ideally both issues should be solved on server level and this PR should be rejected.


<img width="393" alt="image" src="https://github.com/lob/lob-php/assets/5278175/e1712202-4206-494c-96d8-6aa603b43935">