### PR TITLE
Add Armenia to the country list

### DIFF
--- a/lib/Model/CountryExtended.php
+++ b/lib/Model/CountryExtended.php
@@ -58,6 +58,8 @@ enum CountryExtended: string
 
     case AL = 'AL';
 
+    case AM = 'AM';
+
     case AN = 'AN';
 
     case AO = 'AO';

--- a/lib/Model/CountryExtendedExpanded.php
+++ b/lib/Model/CountryExtendedExpanded.php
@@ -66,6 +66,8 @@ enum CountryExtendedExpanded: string
 
     case ARGENTINA = 'ARGENTINA';
 
+    case ARMENIA = 'ARMENIA';
+
     case ARUBA = 'ARUBA';
 
     case AUSTRALIA = 'AUSTRALIA';


### PR DESCRIPTION
## Description

The ISO 3166 country code of Armenia is AM. Armenia is not included in the CountryExtended nor CountryExtendedExpanded enum. Please correct me if it is on purpose and Armenia is indeed an unsupported country.


Closes #178 
