### PR TITLE
Add File Check

### DIFF
--- a/lib/Api/LettersApi.php
+++ b/lib/Api/LettersApi.php
@@ -340,14 +340,19 @@ class LettersApi
             $options = $this->createHttpClientOption();
             $requestError = null;
             try {
+                $multipart = [];
+                if ($file !== null) {
+                    $multipart[] = [
+                        'name' => 'file',
+                        'contents' => Utils::tryFopen($file, 'r')
+                    ];
+                }
+                
                 $response = $this->client->request(
                     'POST',
                     $request->getUri()->__toString(),
                     [
-                        'multipart' => [[
-                            'name' => 'file',
-                            'contents' => Utils::tryFopen($file, 'r')
-                        ]],
+                        'multipart' => $multipart,
                         'auth' => $options['auth']
                     ]
                 );


### PR DESCRIPTION
## Description

Currently when attempting to create a letter without a file attachment, it'll fail due to the Model always trying to read the `$file` variable.

## Story

[JIRA-XXX](https://lobsters.atlassian.net/browse/DXP-XXX)

## Related PR's

[Generator](https://github.com/lob/sdks_openapi_gen/pull/XX)

## Verify

- [ ] Code runs without errors
- [ ] Tests pass with >=85% line coverage
