### PR TITLE
BGSTB-328 | Fix error on GET letters with tracking events

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -16,9 +16,11 @@ jobs:
       
       - uses: php-actions/composer@v6
 
-      - name: Run Tests
-        run: vendor/bin/phpunit --coverage-text --coverage-clover=coverage/coverage.xml --configuration=phpunit.xml.dist
+      - name: Run Unit Tests
+        run: vendor/bin/phpunit --group unit--coverage-text --coverage-clover=coverage/coverage.xml --configuration=phpunit.xml.dist
         env:
           LOB_API_TEST_KEY: ${{ secrets.LOB_API_TEST_KEY }}
           LOB_API_LIVE_KEY: ${{ secrets.LOB_API_LIVE_KEY }}
           XDEBUG_MODE: coverage
+
+      # TODO: Run Integration Tests

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -17,13 +17,8 @@ jobs:
       - uses: php-actions/composer@v6
 
       - name: Run Tests
-        uses: php-actions/phpunit@v3
+        run: vendor/bin/phpunit --coverage-text --coverage-clover=coverage/coverage.xml --configuration=phpunit.xml.dist
         env:
           LOB_API_TEST_KEY: ${{ secrets.LOB_API_TEST_KEY }}
           LOB_API_LIVE_KEY: ${{ secrets.LOB_API_LIVE_KEY }}
           XDEBUG_MODE: coverage
-        with:
-          bootstrap: vendor/autoload.php
-          configuration: phpunit.xml.dist
-          php_extensions: xdebug
-          args: --coverage-text --coverage-clover=coverage/coverage.xml

--- a/lib/Api/LettersApi.php
+++ b/lib/Api/LettersApi.php
@@ -340,17 +340,21 @@ class LettersApi
             $options = $this->createHttpClientOption();
             $requestError = null;
             try {
-                $response = $this->client->request(
-                    'POST',
-                    $request->getUri()->__toString(),
-                    [
-                        'multipart' => [[
-                            'name' => 'file',
-                            'contents' => Utils::tryFopen($file, 'r')
-                        ]],
-                        'auth' => $options['auth']
-                    ]
-                );
+                if ($file !== null) {
+                    $response = $this->client->request(
+                        'POST',
+                        $request->getUri()->__toString(),
+                        [
+                            'multipart' => [[
+                                'name' => 'file',
+                                'contents' => Utils::tryFopen($file, 'r')
+                            ]],
+                            'auth' => $options['auth']
+                        ]
+                    );
+                } else {
+                    $response = $this->client->send($request, $options);
+                }
             } catch (RequestException $e) {
                 $errorBody = json_decode($e->getResponse()->getBody()->getContents())->error;
                 $requestError = new LobError();

--- a/lib/Model/Letter.php
+++ b/lib/Model/Letter.php
@@ -1108,12 +1108,6 @@ class Letter implements ModelInterface, ArrayAccess, \JsonSerializable
      */
     public function setTrackingEvents($tracking_events)
     {
-        if (!method_exists($this, 'getId') || (!empty($this->getId()) && strpos($this->getId(), "fakeId") === False)) {
-
-            if (!is_null($tracking_events) && (count($tracking_events) > 0)) {
-                throw new \InvalidArgumentException('invalid value for $tracking_events when calling Letter., number of items must be less than or equal to 0.');
-            }
-        }
         $this->container['tracking_events'] = [];
         if ($tracking_events) {
             foreach ($tracking_events as $point) {


### PR DESCRIPTION
## Description

- Remove faulty validation logic in the `setTrackingEvents` function for letters
- Update the `run_tests.yml` file to get unit tests running in pull requests
- Add a `null` check in `LettersApi` in order to get all unit tests passing

## Story

https://lobsters.atlassian.net/browse/BGSTB-328